### PR TITLE
Shrink Docker build contexts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Version-control and editor metadata
+.git
+.github
+.idea
+.vscode
+.DS_Store
+
+# Cloud/file-sync conflict copies (for example, "source 2.go")
+**/* [0-9].*
+
+# Local configuration and logs
+.env
+.env.*
+*.log
+
+# Generated build and test output
+bin
+coverage
+coverage.*
+*.out
+*.test
+uploads
+tmp
+
+# The Go service image only needs go.mod, go.sum, cmd, and internal.
+deployments
+docs
+examples
+migrations
+scripts
+sdks
+tests
+web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Check Docker build contexts
+        run: ./scripts/check-docker-context.sh
+
       - name: Build all services
         run: go build ./cmd/...
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
+.PHONY: all build clean test test-docker-context lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
 
 .DEFAULT_GOAL := help
 
@@ -24,6 +24,9 @@ clean: ## Remove built binaries
 
 test: ## Run all tests
 	$(GO) test ./internal/... ./tests/... -race -count=1
+
+test-docker-context: ## Verify local artifacts stay out of Docker build contexts
+	./scripts/check-docker-context.sh
 
 test-coverage: ## Run tests with coverage report
 	$(GO) test ./internal/... ./tests/... -race -coverprofile=coverage.out -covermode=atomic

--- a/deployments/docker/context-check.Dockerfile
+++ b/deployments/docker/context-check.Dockerfile
@@ -1,0 +1,31 @@
+FROM alpine:3.19
+
+ARG CONTEXT_KIND
+
+COPY . /context
+
+RUN test -f /context/kept.txt
+
+RUN if [ "$CONTEXT_KIND" = "root" ]; then \
+        test ! -e /context/.git && \
+        test ! -e /context/.github && \
+        test ! -e /context/web && \
+        test ! -e /context/bin && \
+        test ! -e /context/coverage && \
+        test ! -e /context/uploads && \
+        test ! -e /context/.env && \
+        test ! -e /context/debug.log && \
+        test ! -e "/context/internal/source 2.go"; \
+    elif [ "$CONTEXT_KIND" = "web" ]; then \
+        test ! -e /context/node_modules && \
+        test ! -e /context/.next && \
+        test ! -e /context/coverage && \
+        test ! -e /context/.env.local && \
+        test ! -e /context/npm-debug.log && \
+        test ! -e /context/tsconfig.tsbuildinfo && \
+        test ! -e "/context/src/component 2.tsx" && \
+        test ! -e "/context/public/icon 2.png"; \
+    else \
+        echo "unknown CONTEXT_KIND: $CONTEXT_KIND" >&2; \
+        exit 1; \
+    fi

--- a/scripts/check-docker-context.sh
+++ b/scripts/check-docker-context.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fixture_dir=$(mktemp -d)
+trap 'rm -rf "$fixture_dir"' EXIT HUP INT TERM
+
+root_context="$fixture_dir/root"
+mkdir -p \
+    "$root_context/.git" \
+    "$root_context/.github" \
+    "$root_context/web/node_modules" \
+    "$root_context/web/.next" \
+    "$root_context/bin" \
+    "$root_context/coverage" \
+    "$root_context/internal" \
+    "$root_context/uploads"
+touch \
+    "$root_context/.env" \
+    "$root_context/debug.log" \
+    "$root_context/internal/source 2.go" \
+    "$root_context/kept.txt"
+cp "$project_dir/.dockerignore" "$root_context/.dockerignore"
+
+docker buildx build \
+    --build-arg CONTEXT_KIND=root \
+    --file "$project_dir/deployments/docker/context-check.Dockerfile" \
+    --output type=cacheonly \
+    --progress=plain \
+    "$root_context"
+
+web_context="$fixture_dir/web"
+mkdir -p \
+    "$web_context/node_modules" \
+    "$web_context/.next" \
+    "$web_context/coverage" \
+    "$web_context/public" \
+    "$web_context/src"
+touch \
+    "$web_context/.env.local" \
+    "$web_context/npm-debug.log" \
+    "$web_context/public/icon 2.png" \
+    "$web_context/src/component 2.tsx" \
+    "$web_context/tsconfig.tsbuildinfo" \
+    "$web_context/src/app.ts" \
+    "$web_context/kept.txt"
+cp "$project_dir/web/.dockerignore" "$web_context/.dockerignore"
+
+docker buildx build \
+    --build-arg CONTEXT_KIND=web \
+    --file "$project_dir/deployments/docker/context-check.Dockerfile" \
+    --output type=cacheonly \
+    --progress=plain \
+    "$web_context"

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,18 @@
+# Dependencies and Next.js output are rebuilt inside the image.
+node_modules
+.next
+
+# Local configuration, caches, test output, and logs
+.env
+.env.*
+coverage
+*.log
+*.tsbuildinfo
+
+# Local tooling metadata
+.git
+.gitignore
+.DS_Store
+
+# Cloud/file-sync conflict copies (for example, "component 2.tsx")
+**/* [0-9].*


### PR DESCRIPTION
## What changed

- add focused Docker ignore rules for the Go and Next.js build contexts
- exclude local dependencies, generated output, secrets, logs, and file-sync conflict copies
- add a Docker-backed regression check for both contexts
- run the guard in CI and expose it as make test-docker-context

## Why

Local web/node_modules and web/.next output were being sent to Docker during builds. On the reproduced checkout, the backend context grew to about 881 MB before cancellation, and file-sync conflict copies also entered the Go context and broke compilation.

With this change, the production-style rebuild sent about 23 KB for the Go service context and 2.81 MB for the web context.

## Impact

Docker builds are faster, use less memory and disk I/O, avoid copying local configuration, and are protected from accidental conflict-copy compilation failures.

## Validation

- make test-docker-context
- docker compose -f deployments/docker-compose.yml config --quiet
- docker compose -f deployments/docker-compose.yml up -d --build
- full Go service images built successfully
- Next.js 15 production image built successfully
- API readiness, public feed/community/agent routes, A2A card, and SSR routes returned HTTP 200
- migration version 97, dirty=false
- sh -n scripts/check-docker-context.sh
- git diff --check

Closes #35