### PR TITLE
Fix gateway container health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Check Docker build contexts
         run: ./scripts/check-docker-context.sh
 
+      - name: Check Docker health configuration
+        run: ./scripts/check-compose-health.sh
+
       - name: Build all services
         run: go build ./cmd/...
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test test-docker-context lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
+.PHONY: all build clean test test-docker-context test-compose-health lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
 
 .DEFAULT_GOAL := help
 
@@ -27,6 +27,9 @@ test: ## Run all tests
 
 test-docker-context: ## Verify local artifacts stay out of Docker build contexts
 	./scripts/check-docker-context.sh
+
+test-compose-health: ## Verify service health checks target their configured ports
+	./scripts/check-compose-health.sh
 
 test-coverage: ## Run tests with coverage report
 	$(GO) test ./internal/... ./tests/... -race -coverprofile=coverage.out -covermode=atomic

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       SMTP_FROM: ${SMTP_FROM:-}
       ACS_CONNECTION_STRING: ${ACS_CONNECTION_STRING:-}
       ACS_EMAIL_DOMAIN: ${ACS_EMAIL_DOMAIN:-}
+      HEALTHCHECK_PORT: "8080"
       ENVIRONMENT: development
       LOG_LEVEL: debug
     volumes:
@@ -87,6 +88,7 @@ services:
       DATABASE_URL: postgres://loomfeed:loomfeed@postgres:5432/loomfeed?sslmode=disable
       REDIS_URL: redis://redis:6379
       GATEWAY_PORT: "8081"
+      HEALTHCHECK_PORT: "8081"
       CORE_API_URL: http://api:8080
       ENVIRONMENT: development
       LOG_LEVEL: debug

--- a/scripts/check-compose-health.sh
+++ b/scripts/check-compose-health.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+config_file=$(mktemp)
+trap 'rm -f "$config_file"' EXIT HUP INT TERM
+
+docker compose \
+    --file "$project_dir/deployments/docker-compose.yml" \
+    config \
+    --format json >"$config_file"
+
+if ! jq -e '
+    .services.api.environment.HEALTHCHECK_PORT == "8080" and
+    .services.gateway.environment.HEALTHCHECK_PORT == "8081"
+' "$config_file" >/dev/null; then
+    echo "expected explicit API and gateway health-check ports in resolved Compose config" >&2
+    jq '{
+        api: .services.api.environment.HEALTHCHECK_PORT,
+        gateway: .services.gateway.environment.HEALTHCHECK_PORT
+    }' "$config_file" >&2
+    exit 1
+fi


### PR DESCRIPTION
## What changed

- set HEALTHCHECK_PORT=8080 for the API Compose service
- set HEALTHCHECK_PORT=8081 for the gateway Compose service
- add a resolved-Compose regression check for both service ports
- run the check in CI and expose it as make test-compose-health

## Root cause

The API and gateway share deployments/docker/Dockerfile. Its container health check defaults to port 8080. Compose configured GATEWAY_PORT=8081 for the gateway process but never overrode HEALTHCHECK_PORT, so the service answered /healthz on 8081 while Docker probed 8080 and marked it unhealthy.

## Impact

The gateway now reaches Docker health status healthy, while the API continues to probe its 8080 listener. Compose dependencies and deployment tooling can rely on accurate service health.

## Validation

- red: make test-compose-health reported api=null and gateway=null before the fix
- green: make test-compose-health
- temporary gateway container reached Docker Status=healthy, FailingStreak=0, first probe ExitCode=0
- make test-docker-context
- docker compose -f deployments/docker-compose.yml config --quiet
- sh -n scripts/check-compose-health.sh scripts/check-docker-context.sh
- git diff --check

Closes #36