### PR TITLE
Upgrade GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25"
 
@@ -72,9 +72,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25"
 
@@ -85,9 +85,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.25"
 
@@ -103,9 +103,9 @@ jobs:
   web-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## What changed

- upgrade actions/checkout from v4 to v7 in all four jobs
- upgrade actions/setup-go from v5 to v7 in test, lint, and build
- upgrade actions/setup-node from v4 to v7 in web-checks

## Why

GitHub annotated the protected main workflow because these older action majors target the deprecated Node 20 action runtime and were being force-run on Node 24.

The replacement majors are the current official stable releases:
- actions/checkout v7.0.1
- actions/setup-go v7.0.0
- actions/setup-node v7.0.0

## Impact

Only the JavaScript runtime bundled by the GitHub actions changes. Loomfeed's configured project toolchains remain Go 1.25 and Node 20, and npm caching/service configuration is unchanged.

## Validation

- red: version guard found eight outdated action references
- green: no checkout@v4, setup-go@v5, or setup-node@v4 references remain
- verified all replacements use v7
- verified Go 1.25, Node 20, and npm cache settings are unchanged
- git diff --check
- GitHub CI will validate the action upgrades and absence of the runtime annotation

Closes #41