### PR TITLE
Complete MIT license documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Check MIT license consistency
+        run: ./scripts/check-license.sh
+
       - name: Check Docker build contexts
         run: ./scripts/check-docker-context.sh
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,22 @@
+# Authors and contributors
+
+Loomfeed was created and is maintained by **Surya Koritala**. The repository's
+original MIT notice used RoamXAI as the project copyright name.
+
+The [MIT License](LICENSE) attributes copyright to RoamXAI, Surya Koritala,
+and, for their individual contributions, Loomfeed contributors. All
+contributions included in this repository are distributed under that license.
+
+## Current contributors
+
+- Surya Koritala — creator and maintainer
+
+Git history is the authoritative record of contributions. To generate the
+complete list from a clone, run:
+
+```bash
+git shortlog -sne --all
+```
+
+Automated dependency-update accounts are part of the commit history but are
+not listed here as human authors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,4 +47,6 @@ All participation is covered by our
 ## License
 
 By contributing, you agree that your contributions are licensed under
-the [MIT License](LICENSE).
+the [MIT License](LICENSE). Contributors retain copyright in their individual
+contributions and are recognized through [AUTHORS.md](AUTHORS.md) and the Git
+history.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 RoamXAI
+Copyright (c) 2026 RoamXAI, Surya Koritala, and Loomfeed contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test test-docker-context test-compose-health lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
+.PHONY: all build clean test test-license test-docker-context test-compose-health lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
 
 .DEFAULT_GOAL := help
 
@@ -24,6 +24,9 @@ clean: ## Remove built binaries
 
 test: ## Run all tests
 	$(GO) test ./internal/... ./tests/... -race -count=1
+
+test-license: ## Verify MIT text, attribution, docs, and package metadata
+	./scripts/check-license.sh
 
 test-docker-context: ## Verify local artifacts stay out of Docker build contexts
 	./scripts/check-docker-context.sh

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,9 @@
 loomfeed
-Copyright (c) 2026 RoamXAI
+Copyright (c) 2026 RoamXAI, Surya Koritala, and Loomfeed contributors
 Licensed under the MIT License (see LICENSE).
+
+Project authors and contributors are identified in AUTHORS.md and in the
+Git history.
 
 Third-party notices:
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,17 @@ code style, and the PR process. Security issues go through
 
 ## License
 
-[MIT](LICENSE) — free to use, modify, self-host, and build on.
+Loomfeed is distributed under the [MIT License](LICENSE). Subject to the
+license's notice requirement, it grants permission to:
+
+- Use and copy the software.
+- Modify and merge it.
+- Publish and distribute it.
+- Sublicense and/or sell copies.
+
+The full legal text, including the warranty disclaimer, is in [LICENSE](LICENSE).
+See [Authors and contributors](AUTHORS.md) for project attribution and
+[NOTICE](NOTICE) for third-party licensing information.
 
 The "loomfeed" name and logo identify this project; if you run a
 public fork, please give it its own name.

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+fail() {
+    echo "license check failed: $1" >&2
+    exit 1
+}
+
+require_text() {
+    file=$1
+    expected=$2
+    grep -Fq "$expected" "$project_dir/$file" ||
+        fail "$file is missing: $expected"
+}
+
+license_text=$(tr '\n' ' ' <"$project_dir/LICENSE" | tr -s ' ')
+
+printf '%s' "$license_text" | grep -Fq \
+    'Copyright (c) 2026 RoamXAI, Surya Koritala, and Loomfeed contributors' ||
+    fail 'LICENSE must recognize RoamXAI, Surya Koritala, and Loomfeed contributors'
+printf '%s' "$license_text" | grep -Fq \
+    'Permission is hereby granted, free of charge, to any person obtaining a copy' ||
+    fail 'LICENSE does not contain the canonical MIT opening grant'
+printf '%s' "$license_text" | grep -Fq \
+    'use, copy, modify, merge, publish, distribute, sublicense, and/or sell' ||
+    fail 'LICENSE does not contain the complete canonical MIT permission grant'
+printf '%s' "$license_text" | grep -Fq \
+    'The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.' ||
+    fail 'LICENSE does not contain the canonical MIT notice condition'
+printf '%s' "$license_text" | grep -Fq \
+    'THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND' ||
+    fail 'LICENSE does not contain the canonical MIT warranty disclaimer'
+printf '%s' "$license_text" | grep -Fq \
+    'OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.' ||
+    fail 'LICENSE does not contain the complete canonical MIT liability disclaimer'
+
+require_text AUTHORS.md 'Surya Koritala'
+require_text AUTHORS.md 'git shortlog -sne --all'
+require_text NOTICE 'Copyright (c) 2026 RoamXAI, Surya Koritala, and Loomfeed contributors'
+
+require_text README.md 'Use and copy the software.'
+require_text README.md 'Modify and merge it.'
+require_text README.md 'Publish and distribute it.'
+require_text README.md 'Sublicense and/or sell copies.'
+require_text README.md '[Authors and contributors](AUTHORS.md)'
+
+require_text CONTRIBUTING.md '[MIT License](LICENSE)'
+require_text web/package.json '"license": "MIT"'
+require_text sdks/typescript/package.json '"license": "MIT"'
+require_text sdks/python/setup.py 'license="MIT"'
+
+echo 'MIT license text, attribution, documentation, and package metadata are consistent.'


### PR DESCRIPTION
Closes #43

## What changed

- preserve the canonical MIT license grant and disclaimer while attributing RoamXAI, Surya Koritala, and Loomfeed contributors
- add `AUTHORS.md` with the complete current human contributor list and a reproducible Git-history command
- spell out all MIT-granted actions in the README: use, copy, modify, merge, publish, distribute, sublicense, and sell
- align `NOTICE` and `CONTRIBUTING.md` with the same attribution
- add `make test-license` and run it in CI to prevent licensing drift across the license, public docs, and package metadata

## Why

GitHub already detects the repository as MIT and the legal text was complete, but the README showed only a partial permissions summary and the copyright line omitted the repository's human author. The public presentation should be as complete and consistent as the underlying license.

## User and developer impact

Users can see the complete permission summary and attribution without guessing. Maintainers get a deterministic check that catches missing MIT terms or contradictory SDK/web metadata before merge.

## Validation

- `make test-license`
- `sh -n scripts/check-license.sh`
- `git diff --check`
- compared the legal text with the OSI canonical MIT text: https://opensource.org/license/mit
