### PR TITLE
Persist post and comment provenance atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ ActivityPub     GET  /.well-known/webfinger, /users/{handle}
                 DELETE /api/v1/federation/follows/{id}
 ```
 
+`POST /api/v1/posts` returns the created post fields plus an optional
+`provenance` object when the request supplies `sources`; the same provenance is
+available on subsequent post detail and feed responses.
+
 ## Connect Your Agent
 
 Works against any instance — swap in `http://localhost:8080` for your

--- a/internal/api/handlers/comment.go
+++ b/internal/api/handlers/comment.go
@@ -257,7 +257,20 @@ func (h *CommentHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ThreadType:      req.ThreadType,
 	}
 
-	result, err := h.comments.Create(r.Context(), comment)
+	var result *models.Comment
+	var err error
+	if len(req.Sources) > 0 {
+		var confidence float64
+		if req.ConfidenceScore != nil {
+			confidence = *req.ConfidenceScore
+		}
+		result, err = h.comments.CreateWithProvenance(r.Context(), comment, &models.Provenance{
+			Sources:         req.Sources,
+			ConfidenceScore: confidence,
+		})
+	} else {
+		result, err = h.comments.Create(r.Context(), comment)
+	}
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) || strings.Contains(err.Error(), "parent comment not found") {
 			api.Error(w, http.StatusBadRequest, "parent comment not found")

--- a/internal/api/handlers/comment_test.go
+++ b/internal/api/handlers/comment_test.go
@@ -86,6 +86,61 @@ func TestCommentHandler_Create_Success(t *testing.T) {
 	}
 }
 
+func TestCommentHandler_CreateWithSources_PersistsProvenanceOnRead(t *testing.T) {
+	handler, participants, communities, posts, cfg := setupCommentTest(t)
+	participant, token := registerTestUser(t, participants, cfg, "sourced-comment@example.com", "Sourced Commenter")
+	community := createTestCommunity(t, communities, participant.ID, "sourced-comment-test")
+	post := createTestPost(t, posts, community.ID, participant.ID)
+
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/v1/posts/{id}/comments", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.Create)))
+	mux.HandleFunc("GET /api/v1/posts/{id}/comments", handler.ListByPost)
+
+	confidence := 0.88
+	wantSources := []string{"https://example.com/research", "https://example.org/evidence"}
+	createReq := testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+post.ID+"/comments", token, models.CreateCommentRequest{
+		Body:            "This conclusion is supported by the linked research.",
+		Sources:         wantSources,
+		ConfidenceScore: &confidence,
+	})
+	createRec := httptest.NewRecorder()
+	mux.ServeHTTP(createRec, createReq)
+	testutil.AssertStatus(t, createRec, http.StatusCreated)
+
+	var created models.CommentWithAuthor
+	testutil.DecodeResponse(t, createRec, &created)
+	assertProvenanceSources(t, created.Provenance, wantSources)
+
+	listRec := httptest.NewRecorder()
+	mux.ServeHTTP(listRec, httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+post.ID+"/comments?sort=new&limit=10", nil))
+	testutil.AssertStatus(t, listRec, http.StatusOK)
+
+	var comments []models.CommentWithAuthor
+	testutil.DecodeResponse(t, listRec, &comments)
+	if len(comments) != 1 {
+		t.Fatalf("expected one persisted comment, got %d", len(comments))
+	}
+	if comments[0].ID != created.ID {
+		t.Fatalf("read-back comment ID = %q, want %q", comments[0].ID, created.ID)
+	}
+	assertProvenanceSources(t, comments[0].Provenance, wantSources)
+}
+
+func assertProvenanceSources(t *testing.T, provenance *models.Provenance, want []string) {
+	t.Helper()
+	if provenance == nil {
+		t.Fatal("expected provenance")
+	}
+	if len(provenance.Sources) != len(want) {
+		t.Fatalf("expected %d comment sources, got %d", len(want), len(provenance.Sources))
+	}
+	for i, source := range want {
+		if provenance.Sources[i] != source {
+			t.Errorf("comment source[%d] = %q, want %q", i, provenance.Sources[i], source)
+		}
+	}
+}
+
 func TestCommentHandler_Create_MissingBody(t *testing.T) {
 	handler, participants, communities, posts, cfg := setupCommentTest(t)
 	participant, token := registerTestUser(t, participants, cfg, "nobody@example.com", "NoBody")

--- a/internal/api/handlers/post.go
+++ b/internal/api/handlers/post.go
@@ -639,7 +639,21 @@ func (h *PostHandler) Create(w http.ResponseWriter, r *http.Request) {
 		QuotedPostID:    req.QuotedPostID,
 	}
 
-	result, err := h.posts.Create(r.Context(), post)
+	var result *models.Post
+	var resultProvenance *models.Provenance
+	var err error
+	if len(req.Sources) > 0 {
+		var confidence float64
+		if req.ConfidenceScore != nil {
+			confidence = *req.ConfidenceScore
+		}
+		result, resultProvenance, err = h.posts.CreateWithProvenance(r.Context(), post, &models.Provenance{
+			Sources:         req.Sources,
+			ConfidenceScore: confidence,
+		})
+	} else {
+		result, err = h.posts.Create(r.Context(), post)
+	}
 	if err != nil {
 		api.ErrorWithDetail(w, http.StatusInternalServerError, "failed to create post", err)
 		return
@@ -680,31 +694,6 @@ func (h *PostHandler) Create(w http.ResponseWriter, r *http.Request) {
 				"error", reportErr,
 			)
 		}
-	}
-
-	// Auto-create provenance whenever sources are provided. Agents
-	// always have sources (enforced above); humans get a provenance
-	// row too if they bothered to attribute. Confidence is optional
-	// and defaults to 0 (treated as "not provided" downstream).
-	if len(req.Sources) > 0 {
-		var conf float64
-		if req.ConfidenceScore != nil {
-			conf = *req.ConfidenceScore
-		}
-		prov := &models.Provenance{
-			ContentID:       result.ID,
-			ContentType:     models.TargetPost,
-			AuthorID:        claims.ParticipantID,
-			Sources:         req.Sources,
-			ConfidenceScore: conf,
-		}
-
-		provResult, err := h.provenances.Create(r.Context(), prov)
-		if err != nil {
-			api.Error(w, http.StatusInternalServerError, "failed to create provenance")
-			return
-		}
-		result.ProvenanceID = &provResult.ID
 	}
 
 	// Invalidate feed + activity caches — O(1) version bumps.
@@ -788,7 +777,10 @@ func (h *PostHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 
-	api.JSON(w, http.StatusCreated, result)
+	api.JSON(w, http.StatusCreated, models.CreatePostResponse{
+		Post:       *result,
+		Provenance: resultProvenance,
+	})
 }
 
 // ListRelated handles GET /api/v1/posts/{id}/related. Returns up to

--- a/internal/api/handlers/post_test.go
+++ b/internal/api/handlers/post_test.go
@@ -122,7 +122,7 @@ func TestPostHandler_Create_AgentPostWithProvenance(t *testing.T) {
 
 	testutil.AssertStatus(t, rec, http.StatusCreated)
 
-	var post models.Post
+	var post models.PostWithAuthor
 	testutil.DecodeResponse(t, rec, &post)
 
 	if post.ID == "" {
@@ -134,6 +134,27 @@ func TestPostHandler_Create_AgentPostWithProvenance(t *testing.T) {
 	if post.ProvenanceID == nil {
 		t.Error("expected provenance_id to be set for agent post with sources")
 	}
+	wantSources := []string{"https://source1.com", "https://source2.com"}
+	assertProvenanceSources(t, post.Provenance, wantSources)
+
+	// Read the post back through the public detail endpoint. The create
+	// response alone is not sufficient: provenance must be durably linked so
+	// later feed/detail reads expose the same source trail.
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/posts/{id}", handler.Get)
+	getRec := httptest.NewRecorder()
+	mux.ServeHTTP(getRec, httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+post.ID, nil))
+	testutil.AssertStatus(t, getRec, http.StatusOK)
+
+	var persisted models.PostWithAuthor
+	testutil.DecodeResponse(t, getRec, &persisted)
+	if persisted.ProvenanceID == nil {
+		t.Fatal("expected persisted provenance_id after reading post back")
+	}
+	if persisted.Provenance == nil {
+		t.Fatal("expected persisted provenance after reading post back")
+	}
+	assertProvenanceSources(t, persisted.Provenance, wantSources)
 }
 
 func TestPostHandler_Get_Success(t *testing.T) {

--- a/internal/models/requests.go
+++ b/internal/models/requests.go
@@ -92,6 +92,13 @@ type CreatePostRequest struct {
 	QuotedPostID *string `json:"quoted_post_id,omitempty"`
 }
 
+// CreatePostResponse is the stable 201 representation for post creation.
+// Provenance is present when the request supplied sources.
+type CreatePostResponse struct {
+	Post
+	Provenance *Provenance `json:"provenance,omitempty"`
+}
+
 // === Comment ===
 
 type CreateCommentRequest struct {

--- a/internal/repository/comment.go
+++ b/internal/repository/comment.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/surya-koritala/loomfeed/internal/database"
 	"github.com/surya-koritala/loomfeed/internal/models"
 )
 
@@ -62,12 +63,51 @@ func (r *CommentRepo) Pool() *pgxpool.Pool {
 // Also atomically increments the post's comment_count and the author's
 // comment_count on the participants table using CTEs to reduce round-trips.
 func (r *CommentRepo) Create(ctx context.Context, c *models.Comment) (*models.Comment, error) {
+	return createComment(ctx, r.pool, c)
+}
+
+// CreateWithProvenance creates a comment, its provenance row, and the durable
+// comments.provenance_id link in one transaction. The comment and both counter
+// increments roll back if provenance insertion or attachment fails.
+func (r *CommentRepo) CreateWithProvenance(ctx context.Context, c *models.Comment, provenance *models.Provenance) (*models.Comment, error) {
+	var result *models.Comment
+	err := database.WithTx(ctx, r.pool, func(tx pgx.Tx) error {
+		created, err := createComment(ctx, tx, c)
+		if err != nil {
+			return err
+		}
+
+		provenance.ContentID = created.ID
+		provenance.ContentType = models.TargetComment
+		provenance.AuthorID = created.AuthorID
+		createdProvenance, err := createProvenance(ctx, tx, provenance)
+		if err != nil {
+			return err
+		}
+
+		if _, err := tx.Exec(ctx,
+			`UPDATE comments SET provenance_id = $1 WHERE id = $2`,
+			createdProvenance.ID, created.ID,
+		); err != nil {
+			return fmt.Errorf("attach comment provenance: %w", err)
+		}
+		created.ProvenanceID = &createdProvenance.ID
+		result = created
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func createComment(ctx context.Context, db database.DBTX, c *models.Comment) (*models.Comment, error) {
 	depth := 0
 	if c.ParentCommentID != nil && *c.ParentCommentID != "" {
 		// Parent depth lookup still needed — cannot be combined into the CTE
 		// because we need the depth value for the INSERT.
 		var parentDepth int
-		err := r.pool.QueryRow(ctx, `SELECT depth FROM comments WHERE id = $1 AND deleted_at IS NULL`, *c.ParentCommentID).Scan(&parentDepth)
+		err := db.QueryRow(ctx, `SELECT depth FROM comments WHERE id = $1 AND deleted_at IS NULL`, *c.ParentCommentID).Scan(&parentDepth)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, fmt.Errorf("parent comment not found: %w", pgx.ErrNoRows)
@@ -86,7 +126,7 @@ func (r *CommentRepo) Create(ctx context.Context, c *models.Comment) (*models.Co
 		threadType = "main"
 	}
 
-	err := r.pool.QueryRow(ctx, `
+	err := db.QueryRow(ctx, `
 		WITH inserted AS (
 			INSERT INTO comments
 			  (post_id, parent_comment_id, author_id, author_type, body,
@@ -200,6 +240,9 @@ func (r *CommentRepo) GetByID(ctx context.Context, id string) (*models.Comment, 
 // GetByIDWithAuthor returns a single comment with joined author data.
 func (r *CommentRepo) GetByIDWithAuthor(ctx context.Context, id string) (*models.CommentWithAuthor, error) {
 	var cwa models.CommentWithAuthor
+	var provenanceSources []string
+	var provenanceConfidence *float64
+	var provenanceMethod *string
 	err := r.pool.QueryRow(ctx, `
 		SELECT
 			c.id, c.post_id, c.parent_comment_id, c.author_id, c.author_type,
@@ -209,9 +252,12 @@ func (r *CommentRepo) GetByIDWithAuthor(ctx context.Context, id string) (*models
 			p.id, p.type, p.display_name,
 			COALESCE(p.avatar_url, '') AS avatar_url,
 			COALESCE(p.bio, '') AS bio,
-			p.trust_score, p.reputation_score, p.is_verified, p.created_at, p.updated_at
+			p.trust_score, p.reputation_score, p.is_verified, p.created_at, p.updated_at,
+			COALESCE(prov.sources, '{}') AS provenance_sources,
+			prov.confidence_score, prov.generation_method::text
 		FROM comments c
 		JOIN participants p ON p.id = c.author_id
+		LEFT JOIN provenances prov ON prov.id = c.provenance_id
 		WHERE c.id = $1`, id).Scan(
 		&cwa.ID, &cwa.PostID, &cwa.ParentCommentID, &cwa.AuthorID, &cwa.AuthorType,
 		&cwa.Body, &cwa.ProvenanceID, &cwa.ConfidenceScore,
@@ -221,11 +267,36 @@ func (r *CommentRepo) GetByIDWithAuthor(ctx context.Context, id string) (*models
 		&cwa.Author.AvatarURL, &cwa.Author.Bio,
 		&cwa.Author.TrustScore, &cwa.Author.ReputationScore, &cwa.Author.IsVerified,
 		&cwa.Author.CreatedAt, &cwa.Author.UpdatedAt,
+		&provenanceSources, &provenanceConfidence, &provenanceMethod,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get comment with author: %w", err)
 	}
+	populateCommentProvenance(&cwa, provenanceSources, provenanceConfidence, provenanceMethod)
 	return &cwa, nil
+}
+
+func populateCommentProvenance(c *models.CommentWithAuthor, sources []string, confidence *float64, method *string) {
+	if c.ProvenanceID == nil {
+		return
+	}
+	if sources == nil {
+		sources = []string{}
+	}
+	provenance := &models.Provenance{
+		ID:          *c.ProvenanceID,
+		ContentID:   c.ID,
+		ContentType: models.TargetComment,
+		AuthorID:    c.AuthorID,
+		Sources:     sources,
+	}
+	if confidence != nil {
+		provenance.ConfidenceScore = *confidence
+	}
+	if method != nil {
+		provenance.GenerationMethod = models.GenerationMethod(*method)
+	}
+	c.Provenance = provenance
 }
 
 // Update edits an existing comment's body. Only updates non-deleted comments.
@@ -336,10 +407,13 @@ func (r *CommentRepo) ListByPost(ctx context.Context, postID string, sort string
 			COALESCE(p.bio, '') AS bio,
 			p.trust_score, p.reputation_score, p.is_verified, p.created_at, p.updated_at,
 			COALESCE(a.model_provider, '') AS model_provider,
-			COALESCE(a.model_name, '') AS model_name
+			COALESCE(a.model_name, '') AS model_name,
+			COALESCE(prov.sources, '{}') AS provenance_sources,
+			prov.confidence_score, prov.generation_method::text
 		FROM comments c
 		JOIN participants p ON p.id = c.author_id
 		LEFT JOIN agent_identities a ON a.participant_id = c.author_id
+		LEFT JOIN provenances prov ON prov.id = c.provenance_id
 		`+anchorJoin+`
 		WHERE c.post_id = $1`+modeFilter+cursorFilter+`
 		ORDER BY `+orderBy+`
@@ -355,6 +429,9 @@ func (r *CommentRepo) ListByPost(ctx context.Context, postID string, sort string
 	for rows.Next() {
 		var cwa models.CommentWithAuthor
 		var modelProvider, modelName string
+		var provenanceSources []string
+		var provenanceConfidence *float64
+		var provenanceMethod *string
 		if err := rows.Scan(
 			&cwa.ID, &cwa.PostID, &cwa.ParentCommentID, &cwa.AuthorID, &cwa.AuthorType,
 			&cwa.Body, &cwa.ProvenanceID, &cwa.ConfidenceScore,
@@ -365,11 +442,13 @@ func (r *CommentRepo) ListByPost(ctx context.Context, postID string, sort string
 			&cwa.Author.TrustScore, &cwa.Author.ReputationScore, &cwa.Author.IsVerified,
 			&cwa.Author.CreatedAt, &cwa.Author.UpdatedAt,
 			&modelProvider, &modelName,
+			&provenanceSources, &provenanceConfidence, &provenanceMethod,
 		); err != nil {
 			return nil, fmt.Errorf("scanning comment row: %w", err)
 		}
 		cwa.Author.ModelProvider = modelProvider
 		cwa.Author.ModelName = modelName
+		populateCommentProvenance(&cwa, provenanceSources, provenanceConfidence, provenanceMethod)
 		comments = append(comments, cwa)
 	}
 	if err := rows.Err(); err != nil {
@@ -478,9 +557,12 @@ func (r *CommentRepo) ListDescendants(ctx context.Context, id string, maxDepth, 
 			p.id, p.type, p.display_name,
 			COALESCE(p.avatar_url, '') AS avatar_url,
 			COALESCE(p.bio, '') AS bio,
-			p.trust_score, p.reputation_score, p.is_verified, p.created_at, p.updated_at
+			p.trust_score, p.reputation_score, p.is_verified, p.created_at, p.updated_at,
+			COALESCE(prov.sources, '{}') AS provenance_sources,
+			prov.confidence_score, prov.generation_method::text
 		FROM descendants c
 		JOIN participants p ON p.id = c.author_id
+		LEFT JOIN provenances prov ON prov.id = c.provenance_id
 		ORDER BY c.rel_depth ASC, c.created_at ASC %s`, depthFilter, limitClause)
 
 	rows, err := r.pool.Query(ctx, q, id)
@@ -492,6 +574,9 @@ func (r *CommentRepo) ListDescendants(ctx context.Context, id string, maxDepth, 
 	out := []models.CommentWithAuthor{}
 	for rows.Next() {
 		var cwa models.CommentWithAuthor
+		var provenanceSources []string
+		var provenanceConfidence *float64
+		var provenanceMethod *string
 		if err := rows.Scan(
 			&cwa.ID, &cwa.PostID, &cwa.ParentCommentID, &cwa.AuthorID, &cwa.AuthorType,
 			&cwa.Body, &cwa.ProvenanceID, &cwa.ConfidenceScore,
@@ -501,9 +586,11 @@ func (r *CommentRepo) ListDescendants(ctx context.Context, id string, maxDepth, 
 			&cwa.Author.AvatarURL, &cwa.Author.Bio,
 			&cwa.Author.TrustScore, &cwa.Author.ReputationScore, &cwa.Author.IsVerified,
 			&cwa.Author.CreatedAt, &cwa.Author.UpdatedAt,
+			&provenanceSources, &provenanceConfidence, &provenanceMethod,
 		); err != nil {
 			return nil, fmt.Errorf("scan descendant row: %w", err)
 		}
+		populateCommentProvenance(&cwa, provenanceSources, provenanceConfidence, provenanceMethod)
 		out = append(out, cwa)
 	}
 	return out, rows.Err()

--- a/internal/repository/comment_test.go
+++ b/internal/repository/comment_test.go
@@ -110,6 +110,58 @@ func TestCommentRepo_CreateNested(t *testing.T) {
 	}
 }
 
+func TestCommentRepo_CreateWithProvenance_RollsBackWhenProvenanceFails(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool, "provenances", "comments", "posts", "communities", "participants")
+
+	participantRepo := repository.NewParticipantRepo(pool)
+	communityRepo := repository.NewCommunityRepo(pool)
+	postRepo := repository.NewPostRepo(pool)
+	commentRepo := repository.NewCommentRepo(pool)
+	ctx := context.Background()
+
+	owner := createTestOwner(t, participantRepo, ctx, "comment-provenance-rollback")
+	community := createTestCommunity(t, communityRepo, ctx, owner.ID, "comment-provenance-rollback")
+	post := createTestPost(t, postRepo, ctx, community.ID, owner.ID, "Comment Provenance Rollback")
+
+	_, err := commentRepo.CreateWithProvenance(ctx, &models.Comment{
+		PostID:     post.ID,
+		AuthorID:   owner.ID,
+		AuthorType: models.ParticipantHuman,
+		Body:       "This comment must not survive a provenance failure.",
+	}, &models.Provenance{
+		Sources:          []string{"https://example.com/source"},
+		GenerationMethod: models.GenerationMethod("invalid_generation_method"),
+	})
+	if err == nil {
+		t.Fatal("expected invalid provenance generation method to fail")
+	}
+
+	comments, listErr := commentRepo.ListByPost(ctx, post.ID, "new", 10, 0, "", "")
+	if listErr != nil {
+		t.Fatalf("ListByPost after rollback: %v", listErr)
+	}
+	if len(comments) != 0 {
+		t.Fatalf("expected no comment after provenance rollback, got %d", len(comments))
+	}
+
+	persistedPost, getPostErr := postRepo.GetByID(ctx, post.ID)
+	if getPostErr != nil {
+		t.Fatalf("GetByID post after rollback: %v", getPostErr)
+	}
+	if persistedPost.CommentCount != 0 {
+		t.Fatalf("expected post comment_count rollback to 0, got %d", persistedPost.CommentCount)
+	}
+
+	persistedOwner, getOwnerErr := participantRepo.GetByID(ctx, owner.ID)
+	if getOwnerErr != nil {
+		t.Fatalf("GetByID owner after rollback: %v", getOwnerErr)
+	}
+	if persistedOwner.CommentCount != 0 {
+		t.Fatalf("expected participant comment_count rollback to 0, got %d", persistedOwner.CommentCount)
+	}
+}
+
 func TestCommentRepo_ListByPost(t *testing.T) {
 	pool := database.TestPool(t)
 	database.CleanupTables(t, pool, "reputation_events", "reactions", "votes", "comments", "provenances", "posts", "community_subscriptions", "communities", "api_keys", "agent_identities", "human_users", "participants")

--- a/internal/repository/post.go
+++ b/internal/repository/post.go
@@ -8,7 +8,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/surya-koritala/loomfeed/internal/database"
 	"github.com/surya-koritala/loomfeed/internal/models"
 )
 
@@ -473,6 +475,47 @@ const postJoinSelectWithTotal = `
 // Create inserts a new post. Defaults post_type to "text" if empty.
 // Also atomically increments the author's post_count on the participants table.
 func (r *PostRepo) Create(ctx context.Context, p *models.Post) (*models.Post, error) {
+	return createPost(ctx, r.pool, p)
+}
+
+// CreateWithProvenance creates a post, its provenance row, and the durable
+// posts.provenance_id link in one transaction. No post or counter increment is
+// committed when provenance insertion or attachment fails.
+func (r *PostRepo) CreateWithProvenance(ctx context.Context, p *models.Post, provenance *models.Provenance) (*models.Post, *models.Provenance, error) {
+	var result *models.Post
+	var resultProvenance *models.Provenance
+	err := database.WithTx(ctx, r.pool, func(tx pgx.Tx) error {
+		created, err := createPost(ctx, tx, p)
+		if err != nil {
+			return err
+		}
+
+		provenance.ContentID = created.ID
+		provenance.ContentType = models.TargetPost
+		provenance.AuthorID = created.AuthorID
+		createdProvenance, err := createProvenance(ctx, tx, provenance)
+		if err != nil {
+			return err
+		}
+
+		if _, err := tx.Exec(ctx,
+			`UPDATE posts SET provenance_id = $1 WHERE id = $2`,
+			createdProvenance.ID, created.ID,
+		); err != nil {
+			return fmt.Errorf("attach post provenance: %w", err)
+		}
+		created.ProvenanceID = &createdProvenance.ID
+		result = created
+		resultProvenance = createdProvenance
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return result, resultProvenance, nil
+}
+
+func createPost(ctx context.Context, db database.DBTX, p *models.Post) (*models.Post, error) {
 	if p.PostType == "" {
 		p.PostType = models.PostTypeText
 	}
@@ -491,7 +534,7 @@ func (r *PostRepo) Create(ctx context.Context, p *models.Post) (*models.Post, er
 
 	var result models.Post
 	var resultMetaBytes []byte
-	err = r.pool.QueryRow(ctx, `
+	err = db.QueryRow(ctx, `
 		WITH inserted AS (
 			INSERT INTO posts
 			  (community_id, author_id, author_type, title, body, url, post_type,

--- a/internal/repository/post_test.go
+++ b/internal/repository/post_test.go
@@ -132,6 +132,49 @@ func TestPostRepo_Create_DefaultPostType(t *testing.T) {
 	}
 }
 
+func TestPostRepo_CreateWithProvenance_RollsBackWhenProvenanceFails(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool, "provenances", "posts", "communities", "participants")
+
+	participantRepo := repository.NewParticipantRepo(pool)
+	communityRepo := repository.NewCommunityRepo(pool)
+	postRepo := repository.NewPostRepo(pool)
+	ctx := context.Background()
+
+	owner := createTestOwner(t, participantRepo, ctx, "post-provenance-rollback")
+	community := createTestCommunity(t, communityRepo, ctx, owner.ID, "post-provenance-rollback")
+
+	_, _, err := postRepo.CreateWithProvenance(ctx, &models.Post{
+		CommunityID: community.ID,
+		AuthorID:    owner.ID,
+		AuthorType:  models.ParticipantHuman,
+		Title:       "Must Roll Back",
+		Body:        "The post must not survive a provenance failure.",
+	}, &models.Provenance{
+		Sources:          []string{"https://example.com/source"},
+		GenerationMethod: models.GenerationMethod("invalid_generation_method"),
+	})
+	if err == nil {
+		t.Fatal("expected invalid provenance generation method to fail")
+	}
+
+	posts, total, listErr := postRepo.ListByCommunity(ctx, community.ID, "new", "", 10, 0)
+	if listErr != nil {
+		t.Fatalf("ListByCommunity after rollback: %v", listErr)
+	}
+	if total != 0 || len(posts) != 0 {
+		t.Fatalf("expected no post after provenance rollback, got total=%d rows=%d", total, len(posts))
+	}
+
+	persistedOwner, getErr := participantRepo.GetByID(ctx, owner.ID)
+	if getErr != nil {
+		t.Fatalf("GetByID owner after rollback: %v", getErr)
+	}
+	if persistedOwner.PostCount != 0 {
+		t.Fatalf("expected post_count rollback to 0, got %d", persistedOwner.PostCount)
+	}
+}
+
 func TestPostRepo_ListByCommunity_SortNew(t *testing.T) {
 	pool := database.TestPool(t)
 	database.CleanupTables(t, pool, "posts", "communities", "participants")

--- a/internal/repository/provenance.go
+++ b/internal/repository/provenance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/surya-koritala/loomfeed/internal/database"
 	"github.com/surya-koritala/loomfeed/internal/models"
 )
 
@@ -20,12 +21,19 @@ func NewProvenanceRepo(pool *pgxpool.Pool) *ProvenanceRepo {
 
 // Create inserts a new provenance record. Defaults generation_method to "original" if empty.
 func (r *ProvenanceRepo) Create(ctx context.Context, p *models.Provenance) (*models.Provenance, error) {
+	return createProvenance(ctx, r.pool, p)
+}
+
+// createProvenance inserts through either a pool or an existing transaction.
+// Content repositories use the transaction form so content and its provenance
+// link become visible together or roll back together.
+func createProvenance(ctx context.Context, db database.DBTX, p *models.Provenance) (*models.Provenance, error) {
 	if p.GenerationMethod == "" {
 		p.GenerationMethod = models.MethodOriginal
 	}
 
 	var result models.Provenance
-	err := r.pool.QueryRow(ctx, `
+	err := db.QueryRow(ctx, `
 		INSERT INTO provenances
 		  (content_id, content_type, author_id, sources,
 		   model_used, model_version, prompt_hash,

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -51,7 +51,6 @@ func doJSON(client *http.Client, baseURL, method, path string, body any, token s
 	return result, resp.StatusCode, nil
 }
 
-
 // doJSONArray performs an HTTP request and decodes the response as a JSON array.
 // Used for endpoints that return a bare JSON array (not a paginated object).
 func doJSONArray(client *http.Client, baseURL, method, path string, body any, token string) ([]any, int, error) {
@@ -117,6 +116,49 @@ func getNestedString(t *testing.T, m map[string]any, outerKey, innerKey string) 
 		t.Fatalf("expected %q to be a map, got %T: %v", outerKey, outer, outer)
 	}
 	return getString(t, nested, innerKey)
+}
+
+func assertJSONProvenanceSources(t *testing.T, content map[string]any, want []string) {
+	t.Helper()
+	provenanceValue, ok := content["provenance"]
+	if !ok {
+		t.Fatalf("expected provenance in response: %v", content)
+	}
+	provenance, ok := provenanceValue.(map[string]any)
+	if !ok {
+		t.Fatalf("expected provenance object, got %T: %v", provenanceValue, provenanceValue)
+	}
+	sourcesValue, ok := provenance["sources"]
+	if !ok {
+		t.Fatalf("expected provenance sources: %v", provenance)
+	}
+	sources, ok := sourcesValue.([]any)
+	if !ok {
+		t.Fatalf("expected provenance sources array, got %T: %v", sourcesValue, sourcesValue)
+	}
+	if len(sources) != len(want) {
+		t.Fatalf("expected %d provenance sources, got %d: %v", len(want), len(sources), sources)
+	}
+	for i, source := range want {
+		if sources[i] != source {
+			t.Fatalf("provenance source[%d] = %v, want %q", i, sources[i], source)
+		}
+	}
+}
+
+func assertJSONFeedPostSources(t *testing.T, feed []any, postID string, want []string) {
+	t.Helper()
+	for _, item := range feed {
+		post, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if post["id"] == postID {
+			assertJSONProvenanceSources(t, post, want)
+			return
+		}
+	}
+	t.Fatalf("expected feed to contain post %s", postID)
 }
 
 func TestE2E_HappyPath(t *testing.T) {
@@ -249,7 +291,8 @@ func TestE2E_HappyPath(t *testing.T) {
 		"community_id": communityID,
 		"title":        "Hello World",
 		"body":         "This is the first post in the e2e test.",
-		"post_type": "text",
+		"post_type":    "text",
+		"sources":      []string{"https://example.com/post-source"},
 	}
 	postResp, status, err := doJSON(client, base, http.MethodPost, "/api/v1/posts", postBody, token)
 	if err != nil {
@@ -263,6 +306,7 @@ func TestE2E_HappyPath(t *testing.T) {
 	if postTitle != "Hello World" {
 		t.Fatalf("expected post title=Hello World, got %q", postTitle)
 	}
+	assertJSONProvenanceSources(t, postResp, []string{"https://example.com/post-source"})
 	t.Logf("created post: id=%s title=%s", postID, postTitle)
 
 	// -----------------------------------------------------------------------
@@ -285,6 +329,7 @@ func TestE2E_HappyPath(t *testing.T) {
 	if authorDisplayName != "Alice" {
 		t.Fatalf("expected author display_name=Alice, got %q", authorDisplayName)
 	}
+	assertJSONProvenanceSources(t, getPostResp, []string{"https://example.com/post-source"})
 	t.Logf("get post: author=%s", authorDisplayName)
 
 	// -----------------------------------------------------------------------
@@ -292,7 +337,8 @@ func TestE2E_HappyPath(t *testing.T) {
 	// -----------------------------------------------------------------------
 	t.Log("Step 8: POST /api/v1/posts/{id}/comments")
 	commentBody := map[string]any{
-		"body": "Great post! This is a test comment.",
+		"body":    "Great post! This is a test comment.",
+		"sources": []string{"https://example.org/comment-source"},
 	}
 	commentResp, status, err := doJSON(client, base, http.MethodPost, "/api/v1/posts/"+postID+"/comments", commentBody, token)
 	if err != nil {
@@ -302,6 +348,7 @@ func TestE2E_HappyPath(t *testing.T) {
 		t.Fatalf("expected 201 from create comment, got %d: %v", status, commentResp)
 	}
 	commentID := getString(t, commentResp, "id")
+	assertJSONProvenanceSources(t, commentResp, []string{"https://example.org/comment-source"})
 	t.Logf("created comment: id=%s", commentID)
 
 	// -----------------------------------------------------------------------
@@ -319,6 +366,14 @@ func TestE2E_HappyPath(t *testing.T) {
 	if len(commentsList) == 0 {
 		t.Fatal("expected at least one comment in list")
 	}
+	persistedComment, ok := commentsList[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected comment object, got %T: %v", commentsList[0], commentsList[0])
+	}
+	if gotID := getString(t, persistedComment, "id"); gotID != commentID {
+		t.Fatalf("listed comment id=%q, want %q", gotID, commentID)
+	}
+	assertJSONProvenanceSources(t, persistedComment, []string{"https://example.org/comment-source"})
 	t.Logf("list comments returned %d comments", len(commentsList))
 
 	// -----------------------------------------------------------------------
@@ -365,6 +420,7 @@ func TestE2E_HappyPath(t *testing.T) {
 	if len(feedList) == 0 {
 		t.Fatal("expected at least one post in global feed")
 	}
+	assertJSONFeedPostSources(t, feedList, postID, []string{"https://example.com/post-source"})
 	t.Logf("global feed returned %d posts", len(feedList))
 
 	// -----------------------------------------------------------------------
@@ -390,6 +446,7 @@ func TestE2E_HappyPath(t *testing.T) {
 	if len(commFeedList) == 0 {
 		t.Fatal("expected at least one post in community feed")
 	}
+	assertJSONFeedPostSources(t, commFeedList, postID, []string{"https://example.com/post-source"})
 	t.Logf("community feed returned %d posts", len(commFeedList))
 
 	// -----------------------------------------------------------------------
@@ -426,13 +483,9 @@ func TestE2E_HappyPath(t *testing.T) {
 	// -----------------------------------------------------------------------
 	// Step 14: Create agent post
 	// Note: POST /api/v1/posts uses middleware.Auth (JWT only), not CombinedAuth.
-	// The API key middleware (apikey.go) is not wired into this route.
-	// Agent posts must therefore use the human owner's Bearer token.
-	// Provenance auto-creation requires participant_type="agent" in JWT claims —
-	// which is only set when authenticated via X-API-Key. Since the route uses
-	// JWT-only auth, the post will be created without auto-provenance here.
-	// The sources and confidence_score fields are still submitted as part of the
-	// request body to confirm the handler accepts them without error.
+	// The API key middleware (apikey.go) is not wired into this route, so this
+	// request is attributed to the human owner. Sources are nevertheless durable
+	// for every author and are verified again through the detail read below.
 	// -----------------------------------------------------------------------
 	t.Log("Step 14: POST /api/v1/posts (agent post submitted via owner JWT — JWT-only route)")
 	confidenceScore := 0.92
@@ -473,6 +526,7 @@ func TestE2E_HappyPath(t *testing.T) {
 	if fetchedTitle != "Agent Generated Post" {
 		t.Fatalf("expected title='Agent Generated Post', got %q", fetchedTitle)
 	}
+	assertJSONProvenanceSources(t, getAgentPostResp, []string{"https://example.com/source1", "https://example.com/source2"})
 	t.Logf("get agent post: title=%s", fetchedTitle)
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- creates posts/comments, provenance rows, and their foreign-key links in one PostgreSQL transaction
- rolls back content and denormalized counters when provenance creation fails
- persists comment `sources` and hydrates provenance on create, list, and thread reads
- returns a stable post-create response with optional provenance
- documents the additive post-create response field

## Root cause

Post creation inserted provenance after the post had already committed and only updated the returned Go object. Comment creation accepted `sources` but discarded them. Comment read queries also did not join provenance.

## User impact

Sources returned at creation now remain available on post detail, global/community feeds, and comment reads. Failed provenance writes no longer leave partially created content that users or agents could duplicate by retrying.

## Validation

- `go test ./internal/... ./tests/... -race -count=1 -p 1` — passed against an isolated migrated PostgreSQL database and Redis
- strengthened HTTP E2E flow verifies sourced post/comment creation plus detail, global feed, community feed, and comment-list read-back
- forced provenance failure tests verify post/comment rows and counters roll back
- `go vet ./internal/... ./cmd/... ./tests/...` — passed
- `go build ./cmd/...` — passed
- independent standards review — zero publication blockers
- independent issue-spec review — zero findings

Closes #45