### PR TITLE
Restore authenticated post claim replacement

### DIFF
--- a/internal/api/middleware/apikey.go
+++ b/internal/api/middleware/apikey.go
@@ -412,11 +412,12 @@ func APIKeyAuth(apikeys *repository.APIKeyRepo, sharedCache *cache.RedisCache) f
 			}
 
 			claims := &auth.Claims{
-				ParticipantID:   matchedAgentID,
-				ParticipantType: "agent",
-				Scopes:          matchedScopes,
-				RateLimit:       matchedRateLimit,
-				MaxRPM:          matchedMaxRPM,
+				ParticipantID:       matchedAgentID,
+				ParticipantType:     "agent",
+				Scopes:              matchedScopes,
+				APIKeyAuthenticated: true,
+				RateLimit:           matchedRateLimit,
+				MaxRPM:              matchedMaxRPM,
 			}
 
 			// Cache the result
@@ -466,8 +467,9 @@ func CombinedAuth(apikeys *repository.APIKeyRepo, jwtSecret string, sharedCache 
 }
 
 // RequireScope returns middleware that checks if the authenticated participant has the required scope.
-// JWT-authenticated users (no scopes set) are always allowed through.
-// API key-authenticated agents must have the required scope in their key's scopes list.
+// JWT-authenticated users are always allowed through. API key-authenticated
+// agents must have the required scope in their key's scopes list, including
+// when that list is empty.
 func RequireScope(scope string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -477,8 +479,7 @@ func RequireScope(scope string) func(http.Handler) http.Handler {
 				return
 			}
 
-			// If scopes are set (API key auth), check for the required scope
-			if len(claims.Scopes) > 0 && !containsScope(claims.Scopes, scope) {
+			if claims.APIKeyAuthenticated && !containsScope(claims.Scopes, scope) {
 				http.Error(w, `{"error":"insufficient permissions"}`, http.StatusForbidden)
 				return
 			}

--- a/internal/api/routes/post_claim_test.go
+++ b/internal/api/routes/post_claim_test.go
@@ -1,0 +1,196 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/surya-koritala/loomfeed/internal/auth"
+	"github.com/surya-koritala/loomfeed/internal/config"
+	"github.com/surya-koritala/loomfeed/internal/database"
+	"github.com/surya-koritala/loomfeed/internal/models"
+	"github.com/surya-koritala/loomfeed/internal/repository"
+)
+
+func TestPostClaimReplaceRouteAuthenticationAndOwnership(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool,
+		"claim_citations", "post_claims", "api_keys", "posts", "communities",
+		"agent_identities", "human_users", "participants",
+	)
+
+	ctx := context.Background()
+	participants := repository.NewParticipantRepo(pool)
+	communities := repository.NewCommunityRepo(pool)
+	posts := repository.NewPostRepo(pool)
+	apiKeys := repository.NewAPIKeyRepo(pool)
+	claims := repository.NewPostClaimRepo(pool)
+
+	createHuman := func(suffix string) *models.Participant {
+		t.Helper()
+		participant, err := participants.CreateHuman(ctx, &models.HumanUser{
+			Participant:  models.Participant{DisplayName: "Claims " + suffix},
+			Email:        "claims-" + suffix + "@example.com",
+			PasswordHash: "test-hash",
+		})
+		if err != nil {
+			t.Fatalf("create human %s: %v", suffix, err)
+		}
+		return participant
+	}
+
+	author := createHuman("author")
+	nonAuthor := createHuman("non-author")
+	agent, err := participants.CreateAgent(ctx, &models.AgentIdentity{
+		Participant:       models.Participant{DisplayName: "Claims Agent"},
+		OwnerID:           author.ID,
+		ModelProvider:     "openai",
+		ModelName:         "test-model",
+		Capabilities:      []string{"read", "write"},
+		MaxRPM:            60,
+		ProtocolType:      models.ProtocolREST,
+		HeartbeatInterval: 300,
+	})
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	community, err := communities.Create(ctx, &models.Community{
+		Name:      "Claims Route Tests",
+		Slug:      "claims-route-tests",
+		CreatedBy: author.ID,
+	})
+	if err != nil {
+		t.Fatalf("create community: %v", err)
+	}
+	humanPost, err := posts.Create(ctx, &models.Post{
+		CommunityID: community.ID,
+		AuthorID:    author.ID,
+		AuthorType:  models.ParticipantHuman,
+		Title:       "Human-authored claims post",
+		Body:        "A post used to verify JWT ownership.",
+	})
+	if err != nil {
+		t.Fatalf("create human post: %v", err)
+	}
+	agentPost, err := posts.Create(ctx, &models.Post{
+		CommunityID: community.ID,
+		AuthorID:    agent.ID,
+		AuthorType:  models.ParticipantAgent,
+		Title:       "Agent-authored claims post",
+		Body:        "A post used to verify API-key ownership.",
+	})
+	if err != nil {
+		t.Fatalf("create agent post: %v", err)
+	}
+
+	const jwtSecret = "post-claim-route-test-secret"
+	authorToken, err := auth.GenerateToken(jwtSecret, time.Hour, author.ID, string(author.Type))
+	if err != nil {
+		t.Fatalf("generate author JWT: %v", err)
+	}
+	nonAuthorToken, err := auth.GenerateToken(jwtSecret, time.Hour, nonAuthor.ID, string(nonAuthor.Type))
+	if err != nil {
+		t.Fatalf("generate non-author JWT: %v", err)
+	}
+	createAPIKey := func(scopes []string) string {
+		t.Helper()
+		plain, hash, prefix, err := auth.GenerateAPIKey()
+		if err != nil {
+			t.Fatalf("generate API key: %v", err)
+		}
+		_, err = apiKeys.Create(ctx, &models.APIKey{
+			AgentID:   agent.ID,
+			KeyHash:   hash,
+			KeyPrefix: prefix,
+			Scopes:    scopes,
+			RateLimit: 60,
+			ExpiresAt: time.Now().Add(time.Hour),
+			IsActive:  true,
+		})
+		if err != nil {
+			t.Fatalf("store API key: %v", err)
+		}
+		return plain
+	}
+	emptyScopeKey := createAPIKey([]string{})
+	readKey := createAPIKey([]string{"read"})
+	writeKey := createAPIKey([]string{"read", "write"})
+
+	mux := http.NewServeMux()
+	Register(mux, pool, &config.Config{JWT: config.JWTConfig{Secret: jwtSecret}}, registerOptions{disableBackgroundWorkers: true})
+	replace := func(postID, bearerToken, apiKey, claimText string) *httptest.ResponseRecorder {
+		t.Helper()
+		body := `{"claims":[{"claim_text":"` + claimText + `","citations":[]}]}`
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/posts/"+postID+"/claims", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		if bearerToken != "" {
+			req.Header.Set("Authorization", "Bearer "+bearerToken)
+		}
+		if apiKey != "" {
+			req.Header.Set("X-API-Key", apiKey)
+		}
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	t.Run("anonymous is rejected", func(t *testing.T) {
+		result := replace(humanPost.ID, "", "", "anonymous claim")
+		if result.Code != http.StatusUnauthorized {
+			t.Fatalf("status=%d body=%s", result.Code, result.Body.String())
+		}
+	})
+
+	t.Run("JWT non-author is forbidden", func(t *testing.T) {
+		result := replace(humanPost.ID, nonAuthorToken, "", "non-author claim")
+		if result.Code != http.StatusForbidden {
+			t.Fatalf("status=%d body=%s", result.Code, result.Body.String())
+		}
+	})
+
+	t.Run("JWT author replaces claims", func(t *testing.T) {
+		result := replace(humanPost.ID, authorToken, "", "JWT author claim")
+		if result.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", result.Code, result.Body.String())
+		}
+		stored, err := claims.ListByPost(ctx, humanPost.ID)
+		if err != nil {
+			t.Fatalf("list stored claims: %v", err)
+		}
+		if len(stored) != 1 || stored[0].ClaimText != "JWT author claim" {
+			t.Fatalf("stored claims=%+v", stored)
+		}
+	})
+
+	t.Run("API key without write scope is forbidden", func(t *testing.T) {
+		result := replace(agentPost.ID, "", readKey, "read-only key claim")
+		if result.Code != http.StatusForbidden {
+			t.Fatalf("status=%d body=%s", result.Code, result.Body.String())
+		}
+	})
+
+	t.Run("API key without any scopes is forbidden", func(t *testing.T) {
+		result := replace(agentPost.ID, "", emptyScopeKey, "empty-scope key claim")
+		if result.Code != http.StatusForbidden {
+			t.Fatalf("status=%d body=%s", result.Code, result.Body.String())
+		}
+	})
+
+	t.Run("API key author with write scope replaces claims", func(t *testing.T) {
+		result := replace(agentPost.ID, "", writeKey, "API key author claim")
+		if result.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", result.Code, result.Body.String())
+		}
+		stored, err := claims.ListByPost(ctx, agentPost.ID)
+		if err != nil {
+			t.Fatalf("list stored claims: %v", err)
+		}
+		if len(stored) != 1 || stored[0].ClaimText != "API key author claim" {
+			t.Fatalf("stored claims=%+v", stored)
+		}
+	})
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -35,10 +35,15 @@ import (
 	"github.com/surya-koritala/loomfeed/internal/webhook"
 )
 
+type registerOptions struct {
+	disableBackgroundWorkers bool
+}
+
 func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts ...any) {
 	dir := "uploads"
 	var redisCache *cache.RedisCache
 	var hub *events.Hub
+	disableBackgroundWorkers := false
 	for _, o := range opts {
 		switch v := o.(type) {
 		case string:
@@ -49,6 +54,8 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 			redisCache = v
 		case *events.Hub:
 			hub = v
+		case registerOptions:
+			disableBackgroundWorkers = v.disableBackgroundWorkers
 		}
 	}
 	if hub == nil {
@@ -286,10 +293,12 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	agentSubH := handlers.NewAgentSubscriptionHandler(agentSubs)
 	scorecardH := handlers.NewScorecardHandler(pool)
 
-	// Start scorecard worker (listens for scorecard.trigger events)
-	scorecardWorker := scorecard.NewWorker(pool, hub)
-	go scorecardWorker.Run(context.Background())
-	go provStatsSvc.RunNightly(context.Background())
+	if !disableBackgroundWorkers {
+		// Start scorecard worker (listens for scorecard.trigger events)
+		scorecardWorker := scorecard.NewWorker(pool, hub)
+		go scorecardWorker.Run(context.Background())
+		go provStatsSvc.RunNightly(context.Background())
+	}
 
 	// Agent capability (discovery) repo + handler
 	capRepo := repository.NewAgentCapabilityRepo(pool)
@@ -1076,7 +1085,7 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	postClaimRepo := repository.NewPostClaimRepo(pool)
 	postClaimH := handlers.NewPostClaimHandler(postClaimRepo, posts)
 	mux.HandleFunc("GET /api/v1/posts/{id}/claims", postClaimH.List)
-	mux.HandleFunc("PUT /api/v1/posts/{id}/claims", postClaimH.Replace)
+	mux.Handle("PUT /api/v1/posts/{id}/claims", requireAnyAuth(requireWrite(http.HandlerFunc(postClaimH.Replace))))
 
 	// --- BYOK agents (users create their own AI agent with their own API key) ---
 	byokRepo := repository.NewBYOKAgentRepo(pool)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -16,6 +16,9 @@ type Claims struct {
 	ParticipantID   string   `json:"participant_id"`
 	ParticipantType string   `json:"participant_type"`
 	Scopes          []string `json:"scopes,omitempty"`
+	// APIKeyAuthenticated distinguishes API-key claims from JWT claims when an
+	// API key has an empty scope list. JWT users remain scope-unrestricted.
+	APIKeyAuthenticated bool `json:"-"`
 	// RateLimit is the per-minute request budget for the API key that
 	// produced these claims (0 for JWT/human auth, which carries no key
 	// quota). Populated by APIKeyAuth and enforced cluster-wide there.


### PR DESCRIPTION
## Summary

- restore authentication and write-scope middleware on `PUT /api/v1/posts/{id}/claims`
- keep author ownership enforcement for both JWT users and API-key agents
- make scope enforcement fail closed for API keys with an empty scope list
- add route-level integration coverage without leaking background workers

## End-to-end auth matrix

- anonymous request → 401
- authenticated JWT non-author → 403
- JWT author → 200 and claims persisted
- read-only API key → 403
- empty-scope API key → 403
- write-scoped API-key author → 200 and claims persisted

## Validation

- `go test ./internal/auth ./internal/api/middleware ./internal/api/routes -race -count=1 -p 1`
- `go test ./internal/... ./tests/... -race -count=1 -p 1`
- `go vet ./internal/... ./cmd/... ./tests/...`
- `go build ./cmd/...`
- independent spec and standards/security reviews: zero findings

Closes #46