### PR TITLE
Repair and smoke-test production Docker Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Check Docker health configuration
         run: ./scripts/check-compose-health.sh
 
+      - name: Check production Compose configuration
+        run: ./scripts/check-production-compose.sh
+
       - name: Build all services
         run: go build ./cmd/...
 
@@ -110,7 +113,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 
@@ -156,3 +159,12 @@ jobs:
         # gutting SSR HTML — the class of bug PR #113 and #134 fixed.
         working-directory: web
         run: node scripts/check-ssr-health.mjs
+
+  production-compose-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate and boot production Compose from empty volumes
+        run: ./scripts/smoke-production-compose.sh

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Thumbs.db
 .env
 .env.local
 .env.*.local
+deployments/.env.prod
 
 # Project docs (not tracked)
 agentforum-strategy.docx

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test test-license test-docker-context test-compose-health lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
+.PHONY: all build clean test test-license test-docker-context test-compose-health test-production-compose smoke-production-compose lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
 
 .DEFAULT_GOAL := help
 
@@ -33,6 +33,12 @@ test-docker-context: ## Verify local artifacts stay out of Docker build contexts
 
 test-compose-health: ## Verify service health checks target their configured ports
 	./scripts/check-compose-health.sh
+
+test-production-compose: ## Validate the production Compose runtime contract
+	./scripts/check-production-compose.sh
+
+smoke-production-compose: ## Boot production Compose from empty volumes and probe API/web
+	./scripts/smoke-production-compose.sh
 
 test-coverage: ## Run tests with coverage report
 	$(GO) test ./internal/... ./tests/... -race -coverprofile=coverage.out -covermode=atomic

--- a/deployments/.env.prod.example
+++ b/deployments/.env.prod.example
@@ -1,10 +1,21 @@
 POSTGRES_USER=loomfeed
-POSTGRES_PASSWORD=CHANGE_ME_strong_password_here
+# Use URL-safe values (for example: openssl rand -hex 32). These passwords
+# are embedded in internal postgres:// and redis:// connection URLs.
+POSTGRES_PASSWORD=CHANGE_ME_url_safe_postgres_password
 POSTGRES_DB=loomfeed
-REDIS_PASSWORD=CHANGE_ME_redis_password
-JWT_SECRET=CHANGE_ME_64_char_random_string
+REDIS_PASSWORD=CHANGE_ME_url_safe_redis_password
+JWT_SECRET=CHANGE_ME_url_safe_64_char_random_string
 ALLOWED_ORIGINS=https://yourdomain.com
 SITE_URL=https://yourdomain.com
+
+# Plain HTTP is published for a host-level TLS reverse proxy. Keep these on
+# loopback when Caddy/nginx/Traefik runs on the same server.
+WEB_BIND_ADDRESS=127.0.0.1
+WEB_PORT=3000
+API_BIND_ADDRESS=127.0.0.1
+API_PORT=8080
+
+UPLOADS_ENABLED=false
 FEDERATION_ENABLED=false
 SMTP_HOST=
 SMTP_PORT=587

--- a/deployments/docker-compose.prod.yml
+++ b/deployments/docker-compose.prod.yml
@@ -2,19 +2,48 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in the production env file}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in the production env file}
+      POSTGRES_DB: ${POSTGRES_DB:?set POSTGRES_DB in the production env file}
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     restart: unless-stopped
 
   redis:
     image: redis:7-alpine
-    command: redis-server --requirepass ${REDIS_PASSWORD}
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:?set REDIS_PASSWORD in the production env file}"]
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?set REDIS_PASSWORD in the production env file}
     volumes:
       - redisdata:/data
+    healthcheck:
+      test: ["CMD-SHELL", "REDISCLI_AUTH=\"$${REDIS_PASSWORD}\" redis-cli ping | grep -q PONG"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
     restart: unless-stopped
+
+  migrate:
+    image: migrate/migrate:v4.18.1
+    volumes:
+      - ../migrations:/migrations:ro
+    command:
+      [
+        "-path", "/migrations",
+        "-database", "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable",
+        "up",
+      ]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
 
   api:
     build:
@@ -22,14 +51,17 @@ services:
       dockerfile: deployments/docker/Dockerfile
       args:
         SERVICE: api
+    ports:
+      - "${API_BIND_ADDRESS:-127.0.0.1}:${API_PORT:-8080}:8080"
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
-      JWT_SECRET: ${JWT_SECRET}
+      JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in the production env file}
       ENVIRONMENT: production
       LOG_LEVEL: info
-      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
-      SITE_URL: ${SITE_URL}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:?set ALLOWED_ORIGINS in the production env file}
+      SITE_URL: ${SITE_URL:?set SITE_URL in the production env file}
+      UPLOADS_ENABLED: ${UPLOADS_ENABLED:-false}
       FEDERATION_ENABLED: ${FEDERATION_ENABLED:-false}
       SMTP_HOST: ${SMTP_HOST:-}
       SMTP_PORT: ${SMTP_PORT:-587}
@@ -38,22 +70,47 @@ services:
       SMTP_FROM: ${SMTP_FROM:-}
       ACS_CONNECTION_STRING: ${ACS_CONNECTION_STRING:-}
       ACS_EMAIL_DOMAIN: ${ACS_EMAIL_DOMAIN:-}
+    volumes:
+      - uploads:/app/uploads
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8080/readyz"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
     restart: unless-stopped
 
   web:
     build:
       context: ../web
       dockerfile: Dockerfile
+      args:
+        API_URL: http://api:8080
+        SITE_URL: ${SITE_URL}
     ports:
-      - "443:443"
-      - "80:80"
+      - "${WEB_BIND_ADDRESS:-127.0.0.1}:${WEB_PORT:-3000}:3000"
+    environment:
+      API_URL: http://api:8080
+      SITE_URL: ${SITE_URL}
     depends_on:
-      - api
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:3000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     restart: unless-stopped
 
 volumes:
   pgdata:
   redisdata:
+  uploads:

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -18,7 +18,11 @@ RUN apk add --no-cache ca-certificates tzdata wget
 
 COPY --from=builder /bin/service /usr/local/bin/service
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+WORKDIR /app
+RUN addgroup -S appgroup && \
+    adduser -S appuser -G appgroup && \
+    mkdir -p /app/uploads && \
+    chown appuser:appgroup /app/uploads
 USER appuser
 EXPOSE 8080
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -134,12 +134,61 @@ Notes:
 
 ## Production Deployment
 
-- Terminate TLS at a reverse proxy (Caddy, nginx, Traefik) in front of
-  the web (:3000) and API (:8080) services.
-- Set real values for `JWT_SECRET`, `DATABASE_URL` (managed Postgres
-  with the pgvector extension available), `ALLOWED_ORIGINS`,
-  `SITE_URL`, and `NEXT_PUBLIC_SITE_URL`.
-- Persist the `pgdata` and `uploads` volumes; back up Postgres.
-- Any container platform works (Fly.io, Railway, ECS, Container Apps,
-  a VPS with compose). CI workflows for build/test are included in
-  `.github/workflows/ci.yml`.
+The production Compose file boots Postgres, Redis, a one-shot migration
+container, the API, and the web frontend in dependency order. It publishes
+plain HTTP for an external TLS terminator; it does not contain certificates or
+pretend to listen on port 443.
+
+```bash
+cd deployments
+cp .env.prod.example .env.prod
+
+# Edit every CHANGE_ME value, ALLOWED_ORIGINS, and SITE_URL first.
+# Hex avoids reserved URL characters in the internal connection strings.
+openssl rand -hex 32
+
+docker compose \
+  --env-file .env.prod \
+  --file docker-compose.prod.yml \
+  up --build --detach
+```
+
+The required production variables are `POSTGRES_USER`,
+`POSTGRES_PASSWORD`, `POSTGRES_DB`, `REDIS_PASSWORD`, `JWT_SECRET`,
+`ALLOWED_ORIGINS`, and `SITE_URL`. Compose stops with a configuration error
+when any of them is missing. Use URL-safe Postgres and Redis passwords because
+they are embedded in internal connection URLs.
+
+By default the web is published on port 3000 and the API readiness endpoint is
+published on loopback port 8080. `API_URL=http://api:8080` is already wired
+inside the Compose network, so browser API, upload, MCP, A2A, and WebFinger
+paths can all enter through the web service. Override `WEB_PORT` or `API_PORT`
+when those host ports are occupied.
+
+For a same-host Caddy, nginx, or Traefik installation, keep
+`WEB_BIND_ADDRESS=127.0.0.1` and proxy the public HTTPS origin to
+`http://127.0.0.1:3000`. The web service forwards API paths internally; the API
+port does not need public exposure. If the TLS proxy runs on another machine,
+choose an appropriate `WEB_BIND_ADDRESS` and firewall the published port.
+`SITE_URL` and `ALLOWED_ORIGINS` must use the final public `https://` origin.
+
+Postgres data, Redis data, and local uploads use the named `pgdata`,
+`redisdata`, and `uploads` volumes. The uploads volume is mounted even when
+`UPLOADS_ENABLED=false`, so enabling local uploads later does not change the
+storage topology. Back up Postgres and uploads; Redis data is rebuildable.
+
+Check a deployment with:
+
+```bash
+curl --fail http://127.0.0.1:8080/readyz
+curl --fail http://127.0.0.1:3000/
+```
+
+CI resolves the production file and boots it against empty, project-scoped
+volumes, then verifies API readiness, a web request, and the web-to-API rewrite.
+The same disposable smoke test is available locally as
+`make smoke-production-compose`.
+
+Any container platform also works (Fly.io, Railway, ECS, Container Apps), but
+managed Postgres must provide pgvector and migrations must finish before API
+readiness.

--- a/scripts/check-production-compose.sh
+++ b/scripts/check-production-compose.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -eu
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+config_file=$(mktemp)
+empty_env_file=$(mktemp)
+trap 'rm -f "$config_file" "$empty_env_file"' EXIT HUP INT TERM
+
+if env -i PATH="$PATH" COMPOSE_DISABLE_ENV_FILE=1 docker compose \
+    --env-file "$empty_env_file" \
+    --file "$project_dir/deployments/docker-compose.prod.yml" \
+    config --quiet >/dev/null 2>&1; then
+    echo "production Compose must reject missing required variables" >&2
+    exit 1
+fi
+
+export POSTGRES_USER=${POSTGRES_USER:-loomfeed}
+export POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-prod_config_password}
+export POSTGRES_DB=${POSTGRES_DB:-loomfeed}
+export REDIS_PASSWORD=${REDIS_PASSWORD:-prod_config_redis_password}
+export JWT_SECRET=${JWT_SECRET:-prod_config_jwt_secret}
+export ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:13000}
+export SITE_URL=${SITE_URL:-http://localhost:13000}
+export API_PORT=${API_PORT:-18080}
+export WEB_PORT=${WEB_PORT:-13000}
+export UPLOADS_ENABLED=${UPLOADS_ENABLED:-true}
+unset API_BIND_ADDRESS WEB_BIND_ADDRESS
+
+docker compose \
+    --file "$project_dir/deployments/docker-compose.prod.yml" \
+    config \
+    --format json >"$config_file"
+
+if ! jq -e \
+    --arg api_port "$API_PORT" \
+    --arg web_port "$WEB_PORT" '
+    def publishes($service; $target; $published):
+        any($service.ports[]?; .target == $target and .published == $published);
+    def mounts($service; $target; $source):
+        any($service.volumes[]?; .target == $target and .source == $source);
+
+    .services.migrate != null and
+    publishes(.services.api; 8080; $api_port) and
+    publishes(.services.web; 3000; $web_port) and
+    any(.services.api.ports[]?; .target == 8080 and .host_ip == "127.0.0.1") and
+    any(.services.web.ports[]?; .target == 3000 and .host_ip == "127.0.0.1") and
+    .services.web.build.args.API_URL == "http://api:8080" and
+    .services.web.build.args.SITE_URL == .services.web.environment.SITE_URL and
+    .services.web.environment.API_URL == "http://api:8080" and
+    .services.api.environment.UPLOADS_ENABLED == "true" and
+    .services.postgres.healthcheck != null and
+    .services.redis.healthcheck != null and
+    (.services.api.healthcheck.test | join(" ") | contains("/readyz")) and
+    .services.migrate.depends_on.postgres.condition == "service_healthy" and
+    .services.api.depends_on.postgres.condition == "service_healthy" and
+    .services.api.depends_on.redis.condition == "service_healthy" and
+    .services.api.depends_on.migrate.condition == "service_completed_successfully" and
+    .services.web.depends_on.api.condition == "service_healthy" and
+    .services.web.healthcheck != null and
+    mounts(.services.api; "/app/uploads"; "uploads") and
+    any(.services.migrate.volumes[]?; .target == "/migrations" and .read_only == true) and
+    .volumes.uploads != null
+' "$config_file" >/dev/null; then
+    echo "production Compose config is missing a required runtime guarantee" >&2
+    jq '{
+        services: (.services | with_entries(.value |= {
+            ports,
+            build: {args: {API_URL: .build.args.API_URL, SITE_URL: .build.args.SITE_URL}},
+            environment: {
+                API_URL: .environment.API_URL,
+                SITE_URL: .environment.SITE_URL,
+                UPLOADS_ENABLED: .environment.UPLOADS_ENABLED
+            },
+            healthcheck,
+            depends_on,
+            volumes
+        })),
+        volumes
+    }' "$config_file" >&2
+    exit 1
+fi

--- a/scripts/smoke-production-compose.sh
+++ b/scripts/smoke-production-compose.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -eu
+
+project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+compose_file="$project_dir/deployments/docker-compose.prod.yml"
+project_name=loomfeed-prod-smoke-$(date +%s)-$$
+
+export POSTGRES_USER=${POSTGRES_USER:-loomfeed}
+export POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-prod_smoke_password}
+export POSTGRES_DB=${POSTGRES_DB:-loomfeed}
+export REDIS_PASSWORD=${REDIS_PASSWORD:-prod_smoke_redis_password}
+export JWT_SECRET=${JWT_SECRET:-prod_smoke_jwt_secret}
+export API_BIND_ADDRESS=${API_BIND_ADDRESS:-127.0.0.1}
+export API_PORT=${API_PORT:-18080}
+export WEB_BIND_ADDRESS=${WEB_BIND_ADDRESS:-127.0.0.1}
+export WEB_PORT=${WEB_PORT:-13000}
+export ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://127.0.0.1:$WEB_PORT}
+export SITE_URL=${SITE_URL:-http://127.0.0.1:$WEB_PORT}
+export UPLOADS_ENABLED=${UPLOADS_ENABLED:-true}
+export FEDERATION_ENABLED=true
+
+compose() {
+    docker compose --project-name "$project_name" --file "$compose_file" "$@"
+}
+
+cleanup() {
+    exit_code=$?
+    trap - EXIT HUP INT TERM
+    if [ "$exit_code" -ne 0 ]; then
+        compose ps --all >&2 || true
+        compose logs --no-color >&2 || true
+    fi
+    compose down --volumes --remove-orphans --rmi local >/dev/null 2>&1 || true
+    exit "$exit_code"
+}
+trap cleanup EXIT HUP INT TERM
+
+wait_for_url() {
+    name=$1
+    url=$2
+    attempts=${3:-60}
+    count=1
+    while [ "$count" -le "$attempts" ]; do
+        if curl --fail --silent --location --output /dev/null "$url"; then
+            return 0
+        fi
+        sleep 2
+        count=$((count + 1))
+    done
+    echo "timed out waiting for $name at $url" >&2
+    return 1
+}
+
+compose config --quiet
+compose up --build --detach
+
+wait_for_url "API readiness" "http://127.0.0.1:$API_PORT/readyz"
+wait_for_url "web frontend" "http://127.0.0.1:$WEB_PORT/"
+wait_for_url "web-to-API rewrite" "http://127.0.0.1:$WEB_PORT/api/v1/config"
+
+curl --fail --silent --show-error \
+    --header 'Content-Type: application/json' \
+    --data '{"email":"compose-federation@example.com","password":"compose-smoke-password","display_name":"Compose Federation"}' \
+    "http://127.0.0.1:$WEB_PORT/api/v1/auth/register" >/dev/null
+curl --fail --silent --show-error \
+    "http://127.0.0.1:$WEB_PORT/.well-known/webfinger?resource=acct:composefederation@127.0.0.1" |
+    jq -e '.subject | startswith("acct:composefederation@")' >/dev/null
+curl --fail --silent --show-error \
+    --header 'Accept: application/activity+json' \
+    "http://127.0.0.1:$WEB_PORT/users/composefederation" |
+    jq -e '.preferredUsername == "composefederation" and (.inbox | endswith("/users/composefederation/inbox"))' >/dev/null
+inbox_status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+    --request POST \
+    --header 'Content-Type: application/activity+json' \
+    --data '{}' \
+    "http://127.0.0.1:$WEB_PORT/users/composefederation/inbox")
+if [ "$inbox_status" != "401" ]; then
+    echo "expected unsigned ActivityPub inbox request to reach API and return 401; got $inbox_status" >&2
+    exit 1
+fi
+
+compose exec --no-TTY api sh -c 'printf smoke > /app/uploads/.compose-smoke-marker'
+compose rm --stop --force api
+compose up --detach api
+wait_for_url "recreated API readiness" "http://127.0.0.1:$API_PORT/readyz"
+compose exec --no-TTY api grep -q smoke /app/uploads/.compose-smoke-marker
+
+echo "production Compose smoke test passed"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,15 +1,17 @@
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 ARG API_URL=http://localhost:8080
+ARG SITE_URL=http://localhost:3000
 ARG NEXT_PUBLIC_GIPHY_KEY=
 ENV API_URL=$API_URL
+ENV SITE_URL=$SITE_URL
 ENV NEXT_PUBLIC_GIPHY_KEY=$NEXT_PUBLIC_GIPHY_KEY
 COPY package*.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -8,6 +8,7 @@ const nextConfig = {
       { source: '/uploads/:path*', destination: `${apiUrl}/uploads/:path*` },
       { source: '/mcp/:path*', destination: `${apiUrl}/mcp/:path*` },
       { source: '/.well-known/:path*', destination: `${apiUrl}/.well-known/:path*` },
+      { source: '/users/:path*', destination: `${apiUrl}/users/:path*` },
       { source: '/a2a', destination: `${apiUrl}/a2a` },
     ];
   },


### PR DESCRIPTION
## Summary

- make the production Compose stack fail closed on missing required settings and wait for healthy PostgreSQL/Redis plus completed migrations
- publish loopback-bound API/web ports, wire build-time and runtime `API_URL`, and persist uploads in a named volume
- document TLS termination, production variables, ports, readiness, backups, and the supported deployment command
- add static Compose contract validation and a fresh-database end-to-end smoke test to CI

## End-to-end coverage

The production smoke test builds and boots the real production images from empty volumes, then verifies:

- PostgreSQL and Redis health
- successful schema migrations before API startup
- `/readyz` and the public web port
- API rewriting through the web ingress
- registration, WebFinger, ActivityPub actor, and inbox routing
- upload-volume persistence across API container recreation

## Validation

- `./scripts/check-production-compose.sh`
- `./scripts/smoke-production-compose.sh`
- `./scripts/check-license.sh`
- `./scripts/check-docker-context.sh`
- `./scripts/check-compose-health.sh`
- `git diff --check`
- independent specification and operational/security reviews: no remaining findings

Closes #50