### PR TITLE
Bootstrap communities on fresh installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test test-license test-docker-context test-compose-health test-production-compose smoke-production-compose lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
+.PHONY: all build bootstrap clean test test-license test-docker-context test-compose-health test-production-compose smoke-production-compose lint fmt run-api run-gateway run-provenance run-search migrate-up migrate-down docker-up docker-down help
 
 .DEFAULT_GOAL := help
 
@@ -7,7 +7,7 @@ GO := go
 GOFLAGS := -v
 
 # Services
-SERVICES := api gateway provenance search
+SERVICES := api gateway provenance search bootstrap
 
 help: ## Show available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -86,6 +86,9 @@ docker-build: ## Build Docker images
 
 seed: ## Seed database with demo data (humans, agents, communities, posts)
 	$(GO) run ./cmd/seed
+
+bootstrap: ## Idempotently create safe seed communities (no demo credentials)
+	$(GO) run ./cmd/bootstrap
 
 dev: ## Start Postgres + Redis, run migrations, start API + frontend
 	@echo "Starting Postgres and Redis..."

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ cd loomfeed/deployments
 docker compose up --build
 ```
 
-That's it — Postgres (with pgvector), Redis, migrations, the API,
-the MCP gateway, and the web frontend all come up together, with seed
-communities included. Open **http://localhost:3000**.
+That's it — Postgres (with pgvector), Redis, migrations, the credential-free
+community bootstrap, the API, the MCP gateway, and the web
+frontend all come up together, with seed communities included. No default
+login or shared password is created. Open **http://localhost:3000**.
 
 For running services directly (Go + Node on your machine), production
 hardening, and every environment variable, see the

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/surya-koritala/loomfeed/internal/bootstrap"
+	"github.com/surya-koritala/loomfeed/internal/cache"
+	"github.com/surya-koritala/loomfeed/internal/database"
+)
+
+func main() {
+	ownerEmail := flag.String("owner-email", os.Getenv("BOOTSTRAP_OWNER_EMAIL"),
+		"transfer system-owned bootstrap communities to this registered email")
+	flag.Parse()
+
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		fmt.Fprintln(os.Stderr, "DATABASE_URL is required")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	pool, err := database.Connect(ctx, dbURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "connect to database: %v\n", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	result, err := bootstrap.Run(ctx, pool, bootstrap.Options{OwnerEmail: *ownerEmail})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bootstrap communities: %v\n", err)
+		os.Exit(1)
+	}
+	if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {
+		if err := invalidateCommunityCache(ctx, redisURL); err != nil {
+			fmt.Fprintf(os.Stderr, "invalidate community cache: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		fmt.Fprintf(os.Stderr, "encode bootstrap result: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// invalidateCommunityCache runs even when bootstrap made no database changes.
+// If a previous invocation committed and then lost Redis connectivity, a safe
+// retry therefore repairs cache consistency.
+func invalidateCommunityCache(ctx context.Context, redisURL string) error {
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return fmt.Errorf("parse REDIS_URL: %w", err)
+	}
+	client := redis.NewClient(opts)
+	defer func() { _ = client.Close() }()
+	if err := cache.NewRedisCache(client).BumpVersion(ctx, "community"); err != nil {
+		return fmt.Errorf("bump community cache version: %w", err)
+	}
+	return nil
+}

--- a/deployments/docker-compose.prod.yml
+++ b/deployments/docker-compose.prod.yml
@@ -45,6 +45,24 @@ services:
         condition: service_healthy
     restart: "no"
 
+  bootstrap:
+    build:
+      context: ../
+      dockerfile: deployments/docker/Dockerfile
+      args:
+        SERVICE: bootstrap
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    restart: "no"
+
   api:
     build:
       context: ../
@@ -78,6 +96,8 @@ services:
       redis:
         condition: service_healthy
       migrate:
+        condition: service_completed_successfully
+      bootstrap:
         condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8080/readyz"]

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -41,6 +41,24 @@ services:
       postgres:
         condition: service_healthy
 
+  bootstrap:
+    build:
+      context: ../
+      dockerfile: deployments/docker/Dockerfile
+      args:
+        SERVICE: bootstrap
+    environment:
+      DATABASE_URL: postgres://loomfeed:loomfeed@postgres:5432/loomfeed?sslmode=disable
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    restart: "no"
+
   api:
     build:
       context: ../
@@ -75,6 +93,8 @@ services:
       redis:
         condition: service_healthy
       migrate:
+        condition: service_completed_successfully
+      bootstrap:
         condition: service_completed_successfully
 
   gateway:

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -13,9 +13,10 @@ docker compose up --build
 ```
 
 This brings up PostgreSQL 16 (pgvector image), Redis 7, database
-migrations, the Core API (:8080), the MCP gateway (:8081), and the web
-frontend. Seed communities are created by the migrations, so a fresh
-install isn't empty.
+migrations, the idempotent community bootstrap, the Core API (:8080),
+the MCP gateway (:8081), and the web frontend. The bootstrap uses a
+credential-free system participant, so a fresh install has communities
+without creating a default login or shared password.
 
 Open **http://localhost:3000**.
 
@@ -50,6 +51,10 @@ psql loomfeed -c "SELECT extversion FROM pg_extension WHERE extname = 'vector';"
 # Run migrations
 go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 migrate -path migrations -database "postgres://loomfeed:loomfeed@localhost:5432/loomfeed?sslmode=disable" up
+
+# Create/repair the credential-free starter community catalog
+export DATABASE_URL="postgres://loomfeed:loomfeed@localhost:5432/loomfeed?sslmode=disable"
+go run ./cmd/bootstrap
 ```
 
 ### 2. Backend
@@ -86,6 +91,37 @@ npm run dev        # development
 npm run build      # production
 npm start
 ```
+
+## Bootstrap Ownership and Administration
+
+Starter communities are initially owned by a fixed `system` participant.
+That participant has no `human_users` row, email, password, OAuth identity,
+agent owner, API key, or refresh token, so it cannot log in or act through the API. The
+bootstrap command is idempotent: rerunning it preserves existing community
+IDs and never overwrites a community whose slug an operator already created.
+
+After registering the human account that should administer the starter
+catalog, transfer every community still owned by the system participant:
+
+```bash
+# Development Compose
+docker compose run --rm --no-deps bootstrap --owner-email admin@example.com
+
+# Production Compose (run from deployments/)
+docker compose --env-file .env.prod -f docker-compose.prod.yml \
+  run --rm --no-deps bootstrap --owner-email admin@example.com
+```
+
+The exact email, including letter case, must already be registered. The
+transfer is atomic, promotes that participant to admin moderator, and only
+touches communities still owned by the system participant. Repeating the
+command is a no-op. Compose also invalidates the public community cache after
+each run. For a manual installation, run
+`go run ./cmd/bootstrap --owner-email admin@example.com` with `DATABASE_URL`
+set; also set `REDIS_URL` when running against an active cached instance. The
+database login must be able to assume the non-login `app_service` role. The
+standard migrations grant that membership to their own database login; if you
+use a separate runtime login, grant it with `GRANT app_service TO runtime_role`.
 
 ## Environment Variables
 
@@ -134,10 +170,10 @@ Notes:
 
 ## Production Deployment
 
-The production Compose file boots Postgres, Redis, a one-shot migration
-container, the API, and the web frontend in dependency order. It publishes
-plain HTTP for an external TLS terminator; it does not contain certificates or
-pretend to listen on port 443.
+The production Compose file boots Postgres, Redis, one-shot migration and
+community-bootstrap containers, the API, and the web frontend in dependency
+order. It publishes plain HTTP for an external TLS terminator; it does not
+contain certificates or pretend to listen on port 443.
 
 ```bash
 cd deployments
@@ -185,9 +221,10 @@ curl --fail http://127.0.0.1:3000/
 ```
 
 CI resolves the production file and boots it against empty, project-scoped
-volumes, then verifies API readiness, a web request, and the web-to-API rewrite.
-The same disposable smoke test is available locally as
-`make smoke-production-compose`.
+volumes. It verifies the public catalog, repeatable bootstrap, first-user post,
+ownership handoff, API readiness, web ingress and federation rewrites, and
+upload persistence across API recreation. The same disposable smoke test is
+available locally as `make smoke-production-compose`.
 
 Any container platform also works (Fly.io, Railway, ECS, Container Apps), but
 managed Postgres must provide pgvector and migrations must finish before API

--- a/internal/bootstrap/communities.go
+++ b/internal/bootstrap/communities.go
@@ -1,0 +1,205 @@
+// Package bootstrap creates the minimum safe catalog for a new Loomfeed
+// instance. It is deliberately separate from cmd/seed: bootstrap never creates
+// credentials, example users, agents, posts, or shared passwords.
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/surya-koritala/loomfeed/internal/models"
+)
+
+const SystemParticipantID = "a1110000-0000-4000-8000-000000000001"
+
+// Options controls optional post-registration administration. With no owner
+// email, Run only repairs the system owner and community catalog.
+type Options struct {
+	OwnerEmail string
+}
+
+// Result reports durable changes. A repeated successful Run returns zeros.
+type Result struct {
+	CommunitiesCreated   int64 `json:"communities_created"`
+	OwnershipTransferred int64 `json:"ownership_transferred"`
+}
+
+type communitySeed struct {
+	name        string
+	slug        string
+	description string
+	rules       string
+	category    string
+	policy      models.AgentPolicy
+}
+
+var coreCommunities = []communitySeed{
+	{
+		name: "Open Source AI", slug: "osai", category: "tech", policy: models.AgentPolicyOpen,
+		description: "Open models, local inference, agent interoperability, open tooling, and the communities building AI in public.",
+		rules:       "Link the model, repository, paper, or reproducible artifact behind technical claims. Disclose important licensing and deployment constraints.",
+	},
+	{
+		name: "Machine Learning", slug: "ml", category: "tech", policy: models.AgentPolicyOpen,
+		description: "Machine learning research and practice: architectures, training, evaluation, data quality, optimization, and deployment.",
+		rules:       "Name the dataset, baseline, metric, and evaluation conditions. Distinguish a single result from a replicated finding.",
+	},
+	{
+		name: "AI Safety & Ethics", slug: "ai-safety", category: "society", policy: models.AgentPolicyVerified,
+		description: "Alignment, responsible AI, model behavior, governance, accountability, bias, and the social consequences of deployed systems.",
+		rules:       "Cite primary policy or research sources, separate evidence from forecasts, and state the assumptions behind risk claims.",
+	},
+	{
+		name: "Cybersecurity", slug: "security", category: "tech", policy: models.AgentPolicyVerified,
+		description: "Defensive security, vulnerability research, threat intelligence, secure engineering, incident response, and red-team lessons.",
+		rules:       "Cite advisories or coordinated disclosures. Do not publish weaponized instructions or secrets; distinguish vulnerability from exploitation.",
+	},
+	{
+		name: "Agent Frameworks", slug: "frameworks", category: "tech", policy: models.AgentPolicyOpen,
+		description: "Designing and operating AI agents: protocols, orchestration, tools, memory, evaluation, reliability, and production architecture.",
+		rules:       "Link working code or specifications where possible. Include versions, failure modes, and operational tradeoffs in framework comparisons.",
+	},
+}
+
+// Run ensures a non-login system owner and core community catalog exist. It
+// never overwrites an existing slug. When OwnerEmail is set, communities still
+// owned by the system participant are transferred to that registered human and
+// the human is made an admin moderator in the same transaction.
+func Run(ctx context.Context, pool *pgxpool.Pool, opts Options) (Result, error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("begin bootstrap: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Credential tables use FORCE ROW LEVEL SECURITY. Run the transaction as
+	// the non-login service role created by migration 37; migration 99 grants
+	// that role explicit read policies. If the login role is not authorized to
+	// assume app_service, fail before reading credentials or mutating data.
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE app_service"); err != nil {
+		return Result{}, fmt.Errorf("assume bootstrap database service role: %w", err)
+	}
+	// Keep PUBLIC UUID-based RLS policies well-typed even though the explicit
+	// app_service policies provide the service access needed below.
+	if _, err := tx.Exec(ctx,
+		"SELECT set_config('app.current_user_id', $1, true)", SystemParticipantID,
+	); err != nil {
+		return Result{}, fmt.Errorf("initialize bootstrap RLS context: %w", err)
+	}
+
+	if err := ensureSystemParticipant(ctx, tx); err != nil {
+		return Result{}, err
+	}
+
+	var result Result
+	for _, seed := range coreCommunities {
+		tag, err := tx.Exec(ctx, `
+			INSERT INTO communities
+			    (name, slug, description, rules, agent_policy, quality_threshold, category, created_by)
+			VALUES ($1, $2, $3, $4, $5, 0, $6, $7)
+			ON CONFLICT (slug) DO NOTHING`,
+			seed.name, seed.slug, seed.description, seed.rules,
+			seed.policy, seed.category, SystemParticipantID,
+		)
+		if err != nil {
+			return Result{}, fmt.Errorf("create bootstrap community %q: %w", seed.slug, err)
+		}
+		result.CommunitiesCreated += tag.RowsAffected()
+	}
+
+	ownerEmail := strings.TrimSpace(opts.OwnerEmail)
+	if ownerEmail != "" {
+		transferred, err := transferOwnership(ctx, tx, ownerEmail)
+		if err != nil {
+			return Result{}, err
+		}
+		result.OwnershipTransferred = transferred
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Result{}, fmt.Errorf("commit bootstrap: %w", err)
+	}
+	return result, nil
+}
+
+func ensureSystemParticipant(ctx context.Context, tx pgx.Tx) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO participants
+		    (id, type, display_name, bio, trust_score, reputation_score, is_verified)
+		VALUES ($1, 'system', 'loomfeed',
+		        'Non-login system owner for bootstrapped communities.',
+		        100, 10000, TRUE)
+		ON CONFLICT (id) DO NOTHING`, SystemParticipantID)
+	if err != nil {
+		return fmt.Errorf("ensure bootstrap system participant: %w", err)
+	}
+
+	var participantType string
+	var humanLoginExists, agentIdentityExists, apiKeyExists, refreshTokenExists bool
+	err = tx.QueryRow(ctx, `
+		SELECT p.type::text,
+		       EXISTS (SELECT 1 FROM human_users hu WHERE hu.participant_id = p.id),
+		       EXISTS (SELECT 1 FROM agent_identities ai WHERE ai.participant_id = p.id),
+		       EXISTS (SELECT 1 FROM api_keys ak WHERE ak.agent_id = p.id),
+		       EXISTS (SELECT 1 FROM refresh_tokens rt WHERE rt.participant_id = p.id)
+		FROM participants p
+		WHERE p.id = $1`, SystemParticipantID).Scan(
+		&participantType, &humanLoginExists, &agentIdentityExists, &apiKeyExists,
+		&refreshTokenExists,
+	)
+	if err != nil {
+		return fmt.Errorf("verify bootstrap system participant: %w", err)
+	}
+	if participantType != string(models.ParticipantSystem) ||
+		humanLoginExists || agentIdentityExists || apiKeyExists || refreshTokenExists {
+		return fmt.Errorf("bootstrap participant %s is not a credential-free system identity", SystemParticipantID)
+	}
+	return nil
+}
+
+func transferOwnership(ctx context.Context, tx pgx.Tx, ownerEmail string) (int64, error) {
+	var ownerID string
+	err := tx.QueryRow(ctx, `
+		SELECT hu.participant_id
+		FROM human_users hu
+		WHERE hu.email = $1`, ownerEmail).Scan(&ownerID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return 0, fmt.Errorf("bootstrap owner email %q is not registered", ownerEmail)
+		}
+		return 0, fmt.Errorf("look up bootstrap owner: %w", err)
+	}
+
+	var transferred int64
+	err = tx.QueryRow(ctx, `
+		WITH moved AS (
+			UPDATE communities
+			SET created_by = $1, updated_at = NOW()
+			WHERE created_by = $2
+			RETURNING id
+		), admins AS (
+			INSERT INTO community_moderators (community_id, participant_id, role)
+			SELECT id, $1, 'admin' FROM moved
+			ON CONFLICT (community_id, participant_id)
+			DO UPDATE SET role = 'admin'
+		)
+		SELECT COUNT(*) FROM moved`, ownerID, SystemParticipantID).Scan(&transferred)
+	if err != nil {
+		return 0, fmt.Errorf("transfer bootstrap community ownership: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		DELETE FROM community_moderators cm
+		USING communities c
+		WHERE cm.community_id = c.id
+		  AND cm.participant_id = $1
+		  AND c.created_by = $2`, SystemParticipantID, ownerID)
+	if err != nil {
+		return 0, fmt.Errorf("remove bootstrap system moderator: %w", err)
+	}
+	return transferred, nil
+}

--- a/internal/models/participant.go
+++ b/internal/models/participant.go
@@ -7,6 +7,10 @@ type ParticipantType string
 const (
 	ParticipantHuman ParticipantType = "human"
 	ParticipantAgent ParticipantType = "agent"
+	// ParticipantSystem is a platform-owned identity with no human login,
+	// agent owner, API key, or credentials. It safely owns bootstrap content
+	// until a self-hosting operator transfers that ownership.
+	ParticipantSystem ParticipantType = "system"
 	// ParticipantRemote represents a materialized ActivityPub actor. It has no
 	// login or API-key row and exists only so federated comments/votes reuse the
 	// normal content and author-rendering paths.

--- a/migrations/000098_system_participant_type.down.sql
+++ b/migrations/000098_system_participant_type.down.sql
@@ -1,0 +1,3 @@
+-- PostgreSQL has no DROP VALUE for enums. The companion migration moves the
+-- bootstrap participant back to `human`; leaving the unused value is safe.
+SELECT 1;

--- a/migrations/000098_system_participant_type.up.sql
+++ b/migrations/000098_system_participant_type.up.sql
@@ -1,0 +1,7 @@
+-- Platform-owned identities need a distinct type. Treating the non-login
+-- bootstrap owner as a human inflates human/verification statistics and makes
+-- profile consumers assume a human_users row exists.
+--
+-- The participant row is updated in 000099 because PostgreSQL cannot use a
+-- newly-added enum value until the transaction that added it has committed.
+ALTER TYPE participant_type ADD VALUE IF NOT EXISTS 'system';

--- a/migrations/000099_bootstrap_system_participant.down.sql
+++ b/migrations/000099_bootstrap_system_participant.down.sql
@@ -1,0 +1,10 @@
+-- Preserve the participant and its community foreign keys while restoring a
+-- value understood by code from before migration 98.
+UPDATE participants
+SET type = 'human', updated_at = NOW()
+WHERE id = 'a1110000-0000-4000-8000-000000000001'::uuid
+  AND type = 'system';
+
+DROP POLICY IF EXISTS refresh_tokens_bootstrap_service ON refresh_tokens;
+DROP POLICY IF EXISTS api_keys_bootstrap_service ON api_keys;
+DROP POLICY IF EXISTS human_users_bootstrap_service ON human_users;

--- a/migrations/000099_bootstrap_system_participant.up.sql
+++ b/migrations/000099_bootstrap_system_participant.up.sql
@@ -1,0 +1,57 @@
+-- Migration 57 introduced this fixed participant as a non-login owner for
+-- seeded communities. Give it the system type added in 000098 and ensure the
+-- fixed row exists for databases where a same-named participant predated 57.
+-- Credential tables use FORCE ROW LEVEL SECURITY. Give the existing non-login
+-- background role narrow read access for fail-closed identity verification;
+-- application login roles can use it only when explicitly granted membership.
+CREATE POLICY human_users_bootstrap_service ON human_users
+    FOR SELECT TO app_service USING (current_user = 'app_service');
+CREATE POLICY api_keys_bootstrap_service ON api_keys
+    FOR SELECT TO app_service USING (current_user = 'app_service');
+CREATE POLICY refresh_tokens_bootstrap_service ON refresh_tokens
+    FOR SELECT TO app_service USING (current_user = 'app_service');
+
+SET LOCAL ROLE app_service;
+-- Keep the pre-existing PUBLIC UUID policies well-typed while the explicit
+-- app_service policies expose the credential rows required by the guard.
+SELECT set_config(
+    'app.current_user_id',
+    'a1110000-0000-4000-8000-000000000001',
+    true
+);
+
+INSERT INTO participants (
+    id, type, display_name, bio, trust_score, reputation_score, is_verified
+)
+VALUES (
+    'a1110000-0000-4000-8000-000000000001'::uuid,
+    'system',
+    'loomfeed',
+    'Non-login system owner for bootstrapped communities.',
+    100,
+    10000,
+    TRUE
+)
+ON CONFLICT (id) DO UPDATE
+SET type = 'system',
+    bio = EXCLUDED.bio,
+    is_verified = TRUE,
+    updated_at = NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM human_users
+    WHERE participant_id = EXCLUDED.id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM agent_identities
+    WHERE participant_id = EXCLUDED.id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM api_keys
+    WHERE agent_id = EXCLUDED.id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM refresh_tokens
+    WHERE participant_id = EXCLUDED.id
+);
+
+RESET ROLE;

--- a/scripts/check-production-compose.sh
+++ b/scripts/check-production-compose.sh
@@ -40,6 +40,11 @@ if ! jq -e \
         any($service.volumes[]?; .target == $target and .source == $source);
 
     .services.migrate != null and
+    .services.bootstrap != null and
+    .services.bootstrap.build.args.SERVICE == "bootstrap" and
+    .services.bootstrap.environment.DATABASE_URL != null and
+    .services.bootstrap.environment.REDIS_URL != null and
+    .services.bootstrap.restart == "no" and
     publishes(.services.api; 8080; $api_port) and
     publishes(.services.web; 3000; $web_port) and
     any(.services.api.ports[]?; .target == 8080 and .host_ip == "127.0.0.1") and
@@ -52,9 +57,13 @@ if ! jq -e \
     .services.redis.healthcheck != null and
     (.services.api.healthcheck.test | join(" ") | contains("/readyz")) and
     .services.migrate.depends_on.postgres.condition == "service_healthy" and
+    .services.bootstrap.depends_on.postgres.condition == "service_healthy" and
+    .services.bootstrap.depends_on.redis.condition == "service_healthy" and
+    .services.bootstrap.depends_on.migrate.condition == "service_completed_successfully" and
     .services.api.depends_on.postgres.condition == "service_healthy" and
     .services.api.depends_on.redis.condition == "service_healthy" and
     .services.api.depends_on.migrate.condition == "service_completed_successfully" and
+    .services.api.depends_on.bootstrap.condition == "service_completed_successfully" and
     .services.web.depends_on.api.condition == "service_healthy" and
     .services.web.healthcheck != null and
     mounts(.services.api; "/app/uploads"; "uploads") and

--- a/scripts/smoke-production-compose.sh
+++ b/scripts/smoke-production-compose.sh
@@ -58,10 +58,113 @@ wait_for_url "API readiness" "http://127.0.0.1:$API_PORT/readyz"
 wait_for_url "web frontend" "http://127.0.0.1:$WEB_PORT/"
 wait_for_url "web-to-API rewrite" "http://127.0.0.1:$WEB_PORT/api/v1/config"
 
-curl --fail --silent --show-error \
+system_identity_state=$(compose exec --no-TTY postgres psql \
+    --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" --tuples-only \
+    --no-align --field-separator '|' --command \
+    "SELECT p.type::text,
+            (SELECT COUNT(*) FROM human_users WHERE participant_id = p.id),
+            (SELECT COUNT(*) FROM agent_identities WHERE participant_id = p.id),
+            (SELECT COUNT(*) FROM api_keys WHERE agent_id = p.id),
+            (SELECT COUNT(*) FROM refresh_tokens WHERE participant_id = p.id)
+     FROM participants p
+     WHERE p.id = 'a1110000-0000-4000-8000-000000000001'::uuid")
+if [ "$system_identity_state" != "system|0|0|0|0" ]; then
+    echo "bootstrap owner is not a credential-free system identity: $system_identity_state" >&2
+    exit 1
+fi
+
+# Prove the bootstrap does not rely on the privileged Compose database owner.
+# A forced-RLS credential collision must be visible to a restricted role and
+# fail closed; after cleanup, the same role must complete an idempotent rerun.
+compose exec --no-TTY postgres psql \
+    --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" --set ON_ERROR_STOP=1 \
+    --command "CREATE ROLE bootstrap_smoke LOGIN PASSWORD 'bootstrap_smoke_password'" \
+    --command "GRANT CONNECT ON DATABASE \"$POSTGRES_DB\" TO bootstrap_smoke" \
+    --command "GRANT app_service TO bootstrap_smoke" \
+    --command "INSERT INTO refresh_tokens (participant_id, token_hash, expires_at)
+               VALUES ('a1110000-0000-4000-8000-000000000001'::uuid,
+                       'bootstrap-smoke-collision', NOW() + INTERVAL '1 hour')"
+restricted_database_url="postgres://bootstrap_smoke:bootstrap_smoke_password@postgres:5432/$POSTGRES_DB?sslmode=disable"
+visible_credentials=$(compose exec --no-TTY \
+    --env PGPASSWORD=bootstrap_smoke_password postgres psql \
+    --username bootstrap_smoke --dbname "$POSTGRES_DB" --tuples-only --no-align \
+    --command "SELECT COUNT(*) FROM refresh_tokens")
+if [ "$visible_credentials" != "0" ]; then
+    echo "app_service membership exposed credentials before SET ROLE" >&2
+    exit 1
+fi
+if compose run --rm --no-deps --env DATABASE_URL="$restricted_database_url" bootstrap >/dev/null 2>&1; then
+    echo "restricted-role bootstrap accepted a credential-bearing system identity" >&2
+    exit 1
+fi
+compose exec --no-TTY postgres psql \
+    --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" --set ON_ERROR_STOP=1 \
+    --command "DELETE FROM refresh_tokens WHERE token_hash = 'bootstrap-smoke-collision'" >/dev/null
+restricted_rerun=$(compose run --rm --no-deps \
+    --env DATABASE_URL="$restricted_database_url" bootstrap)
+printf '%s' "$restricted_rerun" |
+    jq -e '.communities_created == 0 and .ownership_transferred == 0' >/dev/null
+
+catalog=$(curl --fail --silent --show-error \
+    "http://127.0.0.1:$WEB_PORT/api/v1/communities?limit=500")
+community_id=$(printf '%s' "$catalog" | jq -er \
+    'if length > 0 then .[0].id else error("fresh install returned an empty community catalog") end')
+catalog_fingerprint=$(printf '%s' "$catalog" | jq -S -r 'sort_by(.slug) | map([.id, .slug])')
+
+# The supported bootstrap command must be safe for operators to rerun. The
+# public catalog is the seam: successful no-op reruns preserve every seed ID
+# and slug instead of duplicating or replacing communities.
+bootstrap_rerun_one=$(compose run --rm --no-deps bootstrap)
+printf '%s' "$bootstrap_rerun_one" |
+    jq -e '.communities_created == 0 and .ownership_transferred == 0' >/dev/null
+bootstrap_rerun_two=$(compose run --rm --no-deps bootstrap)
+printf '%s' "$bootstrap_rerun_two" |
+    jq -e '.communities_created == 0 and .ownership_transferred == 0' >/dev/null
+catalog_after_rerun=$(curl --fail --silent --show-error \
+    "http://127.0.0.1:$WEB_PORT/api/v1/communities?limit=500&sort=alphabetical")
+catalog_fingerprint_after_rerun=$(printf '%s' "$catalog_after_rerun" | jq -S -r 'sort_by(.slug) | map([.id, .slug])')
+if [ "$catalog_fingerprint" != "$catalog_fingerprint_after_rerun" ]; then
+    echo "repeated bootstrap changed the public community catalog" >&2
+    exit 1
+fi
+
+registration=$(curl --fail --silent --show-error \
     --header 'Content-Type: application/json' \
     --data '{"email":"compose-federation@example.com","password":"compose-smoke-password","display_name":"Compose Federation"}' \
-    "http://127.0.0.1:$WEB_PORT/api/v1/auth/register" >/dev/null
+    "http://127.0.0.1:$WEB_PORT/api/v1/auth/register")
+access_token=$(printf '%s' "$registration" | jq -er '.access_token')
+participant_id=$(printf '%s' "$registration" | jq -er '.participant.id')
+
+post_body=$(jq -n --arg community_id "$community_id" '{
+    community_id: $community_id,
+    title: "First post on a fresh Loomfeed install",
+    body: "This post verifies that a newly registered human can participate in a bootstrapped community.",
+    post_type: "text"
+}')
+curl --fail --silent --show-error \
+    --header 'Content-Type: application/json' \
+    --header "Authorization: Bearer $access_token" \
+    --data "$post_body" \
+    "http://127.0.0.1:$WEB_PORT/api/v1/posts" |
+    jq -e --arg community_id "$community_id" '.community_id == $community_id and (.id | length > 0)' >/dev/null
+
+ownership_result=$(compose run --rm --no-deps \
+    --env DATABASE_URL="$restricted_database_url" bootstrap \
+    --owner-email compose-federation@example.com)
+printf '%s' "$ownership_result" | jq -e '.ownership_transferred > 0' >/dev/null
+catalog_after_transfer=$(curl --fail --silent --show-error \
+    "http://127.0.0.1:$WEB_PORT/api/v1/communities?limit=500")
+printf '%s' "$catalog_after_transfer" | jq -e \
+    --arg owner_id "$participant_id" \
+    --arg system_id 'a1110000-0000-4000-8000-000000000001' \
+    'length > 0 and
+     any(.[]; .created_by == $owner_id) and
+     all(.[]; .created_by != $system_id)' >/dev/null
+ownership_rerun=$(compose run --rm --no-deps \
+    --env DATABASE_URL="$restricted_database_url" bootstrap \
+    --owner-email compose-federation@example.com)
+printf '%s' "$ownership_rerun" | jq -e '.ownership_transferred == 0' >/dev/null
+
 curl --fail --silent --show-error \
     "http://127.0.0.1:$WEB_PORT/.well-known/webfinger?resource=acct:composefederation@127.0.0.1" |
     jq -e '.subject | startswith("acct:composefederation@")' >/dev/null


### PR DESCRIPTION
## Summary

- add a credential-free `system` participant type and an idempotent community bootstrap command
- run bootstrap between migrations and API startup in development and production Compose
- support exact-email ownership transfer and immediately invalidate the public community cache
- enforce credential collision checks under forced RLS, including human, agent, API-key, and refresh-token identities
- document self-hosted bootstrap administration

## End-to-end validation

- fresh production Compose volumes migrate and bootstrap successfully
- public community catalog is non-empty and stable across repeat bootstrap runs
- restricted database login cannot read credential rows before explicit service-role assumption
- injected credential collision fails closed; clean restricted-role retry succeeds
- newly registered human creates a first post in a bootstrapped community
- ownership handoff is visible immediately through the cached public API
- ActivityPub ingress and upload persistence smoke checks remain green
- `go test -race ./... -count=1`
- `go vet ./...`
- license, Docker context, Compose health, and production Compose checks

Closes #51