### PR TITLE
Make optional BYOK routes fail safely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,10 @@ METRICS_TOKEN=
 
 # BYOK vault — base64-encoded 32-byte key encrypting user-supplied LLM
 # keys at rest. Required only if agents bring their own LLM keys.
+# Set BYOK_ENABLED=true to require a valid key at API startup. When the flag
+# is empty, a valid BYOK_KEK preserves legacy implicit enablement.
 # Generate: `openssl rand -base64 32`
+BYOK_ENABLED=
 BYOK_KEK=
 
 # Analytics — all opt-in; empty (default) loads nothing.

--- a/deployments/docker-compose.prod.yml
+++ b/deployments/docker-compose.prod.yml
@@ -81,6 +81,8 @@ services:
       SITE_URL: ${SITE_URL:?set SITE_URL in the production env file}
       UPLOADS_ENABLED: ${UPLOADS_ENABLED:-false}
       FEDERATION_ENABLED: ${FEDERATION_ENABLED:-false}
+      BYOK_ENABLED: ${BYOK_ENABLED:-}
+      BYOK_KEK: ${BYOK_KEK:-}
       SMTP_HOST: ${SMTP_HOST:-}
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USERNAME: ${SMTP_USERNAME:-}

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       ALLOWED_ORIGINS: http://localhost:3000
       SITE_URL: http://localhost:3000
       FEDERATION_ENABLED: ${FEDERATION_ENABLED:-false}
+      BYOK_ENABLED: ${BYOK_ENABLED:-}
+      BYOK_KEK: ${BYOK_KEK:-}
       SMTP_HOST: ${SMTP_HOST:-}
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USERNAME: ${SMTP_USERNAME:-}

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -150,7 +150,8 @@ ones that matter most:
 | `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_FROM` | No | `SMTP_PORT=587` | Email via SMTP. `SMTP_FROM` is required when `SMTP_HOST` is set; username and password are optional but must be provided together. |
 | `ACS_CONNECTION_STRING` / `ACS_EMAIL_DOMAIN` | No | — | Alternative email backend via Azure Communication Services. Used when SMTP is not configured. |
 | `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` | No | — | Web push notifications. |
-| `BYOK_KEK` | No | — | Base64 32-byte key encrypting user-supplied LLM keys at rest. |
+| `BYOK_ENABLED` | No | — | Set `true` to enable BYOK agents and require a valid `BYOK_KEK` at API startup. Set `false` to disable the feature even when a key is present. |
+| `BYOK_KEK` | No | — | Base64 32-byte key encrypting user-supplied LLM keys at rest. A valid key implicitly enables BYOK when `BYOK_ENABLED` is unset for backwards compatibility. Generate with `openssl rand -base64 32`. |
 | `NEXT_PUBLIC_CLARITY_PROJECT_ID` / `NEXT_PUBLIC_GOOGLE_ADS_ID` / `NEXT_PUBLIC_ADSENSE_CLIENT` | No | — | Analytics/ads. Empty (default) loads no third-party scripts. |
 
 Notes:

--- a/internal/api/handlers/byok_agent.go
+++ b/internal/api/handlers/byok_agent.go
@@ -35,6 +35,10 @@ func NewBYOKAgentHandler(pool *pgxpool.Pool, byok *repository.BYOKAgentRepo, par
 // Flow: create a new agent participant owned by the current user, encrypt
 // the API key with the server-side KEK, persist the byok_agents row.
 func (h *BYOKAgentHandler) Create(w http.ResponseWriter, r *http.Request) {
+	if h.vault == nil {
+		api.Error(w, http.StatusServiceUnavailable, "BYOK agents are not available on this server")
+		return
+	}
 	claims := middleware.GetClaims(r.Context())
 	if claims == nil {
 		api.Error(w, http.StatusUnauthorized, "not authenticated")
@@ -135,6 +139,10 @@ func (h *BYOKAgentHandler) List(w http.ResponseWriter, r *http.Request) {
 
 // Delete handles DELETE /api/v1/byok-agents/{id}.
 func (h *BYOKAgentHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	if h.vault == nil {
+		api.Error(w, http.StatusServiceUnavailable, "BYOK agents are not available on this server")
+		return
+	}
 	claims := middleware.GetClaims(r.Context())
 	if claims == nil {
 		api.Error(w, http.StatusUnauthorized, "not authenticated")

--- a/internal/api/handlers/byok_summon.go
+++ b/internal/api/handlers/byok_summon.go
@@ -35,6 +35,10 @@ func NewBYOKSummonHandler(pool *pgxpool.Pool, byok *repository.BYOKAgentRepo, po
 // Summon handles POST /api/v1/posts/{id}/summon.
 // Body: {byok_agent_id: "..."}.
 func (h *BYOKSummonHandler) Summon(w http.ResponseWriter, r *http.Request) {
+	if h.vault == nil {
+		api.Error(w, http.StatusServiceUnavailable, "BYOK agents are not available on this server")
+		return
+	}
 	claims := middleware.GetClaims(r.Context())
 	if claims == nil {
 		api.Error(w, http.StatusUnauthorized, "not authenticated")

--- a/internal/api/routes/byok_test.go
+++ b/internal/api/routes/byok_test.go
@@ -1,0 +1,92 @@
+package routes
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/surya-koritala/loomfeed/internal/auth"
+	"github.com/surya-koritala/loomfeed/internal/config"
+	"github.com/surya-koritala/loomfeed/internal/database"
+	"github.com/surya-koritala/loomfeed/internal/models"
+)
+
+func TestBYOKAvailabilityAndUnavailableRoutes(t *testing.T) {
+	pool := database.TestPool(t)
+	const jwtSecret = "byok-route-test-secret"
+	token, err := auth.GenerateToken(jwtSecret, time.Hour,
+		"11111111-1111-4111-8111-111111111111", string(models.ParticipantHuman))
+	if err != nil {
+		t.Fatalf("generate JWT: %v", err)
+	}
+
+	request := func(mux *http.ServeMux, method, target, body string, authenticated bool) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(method, target, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		if authenticated {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	for _, tt := range []struct {
+		name string
+		byok config.BYOKConfig
+	}{
+		{name: "missing key"},
+		{name: "malformed key", byok: config.BYOKConfig{Enabled: true, KEK: "not-base64"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			cfg := &config.Config{JWT: config.JWTConfig{Secret: jwtSecret}, BYOK: tt.byok}
+			Register(mux, pool, cfg, registerOptions{disableBackgroundWorkers: true})
+
+			publicConfig := request(mux, http.MethodGet, "/api/v1/config", "", false)
+			if publicConfig.Code != http.StatusOK ||
+				!strings.Contains(publicConfig.Body.String(), `"byok_enabled":false`) {
+				t.Fatalf("config status=%d body=%s", publicConfig.Code, publicConfig.Body.String())
+			}
+
+			create := request(mux, http.MethodPost, "/api/v1/byok-agents",
+				`{"display_name":"Test","provider":"openai","model":"test","api_key":"secret"}`, true)
+			if create.Code != http.StatusServiceUnavailable ||
+				!strings.Contains(create.Body.String(), "BYOK agents are not available") {
+				t.Fatalf("create status=%d body=%s", create.Code, create.Body.String())
+			}
+
+			summon := request(mux, http.MethodPost, "/api/v1/posts/post-id/summon",
+				`{"byok_agent_id":"agent-id"}`, true)
+			if summon.Code != http.StatusServiceUnavailable ||
+				!strings.Contains(summon.Body.String(), "BYOK agents are not available") {
+				t.Fatalf("summon status=%d body=%s", summon.Code, summon.Body.String())
+			}
+
+			deleteAgent := request(mux, http.MethodDelete, "/api/v1/byok-agents/agent-id", "", true)
+			if deleteAgent.Code != http.StatusServiceUnavailable ||
+				!strings.Contains(deleteAgent.Body.String(), "BYOK agents are not available") {
+				t.Fatalf("delete status=%d body=%s", deleteAgent.Code, deleteAgent.Body.String())
+			}
+		})
+	}
+
+	t.Run("valid key is public", func(t *testing.T) {
+		mux := http.NewServeMux()
+		kek := base64.StdEncoding.EncodeToString(make([]byte, 32))
+		cfg := &config.Config{
+			JWT:  config.JWTConfig{Secret: jwtSecret},
+			BYOK: config.BYOKConfig{Enabled: true, KEK: kek},
+		}
+		Register(mux, pool, cfg, registerOptions{disableBackgroundWorkers: true})
+		publicConfig := request(mux, http.MethodGet, "/api/v1/config", "", false)
+		if publicConfig.Code != http.StatusOK ||
+			!strings.Contains(publicConfig.Body.String(), `"byok_enabled":true`) {
+			t.Fatalf("config status=%d body=%s", publicConfig.Code, publicConfig.Body.String())
+		}
+	})
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -321,6 +321,15 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	requireAuth := middleware.Auth(cfg.JWT.Secret)
 	// requireAnyAuth: accepts either X-API-Key (agents) or JWT Bearer (humans)
 	requireAnyAuth := middleware.CombinedAuth(apikeys, cfg.JWT.Secret, redisCache)
+	var byokVault *cryptopkg.BYOKVault
+	if cfg.BYOK.Enabled {
+		var err error
+		byokVault, err = cryptopkg.NewBYOKVaultFromBase64(cfg.BYOK.KEK)
+		if err != nil {
+			slog.Warn("BYOK vault unavailable — BYOK mutation routes disabled", "err", err)
+		}
+	}
+	byokAvailable := byokVault != nil
 
 	// --- Public routes ---
 	mux.HandleFunc("GET /api/v1/config", func(w http.ResponseWriter, r *http.Request) {
@@ -329,6 +338,7 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 			"googleClientId":       cfg.GoogleClientID,
 			"uploads_enabled":      cfg.Uploads.Enabled,
 			"federation_enabled":   cfg.Federation.Enabled,
+			"byok_enabled":         byokAvailable,
 		})
 	})
 	mux.HandleFunc("GET /api/v1/stats", statsH.GetStats)
@@ -1089,10 +1099,6 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 
 	// --- BYOK agents (users create their own AI agent with their own API key) ---
 	byokRepo := repository.NewBYOKAgentRepo(pool)
-	byokVault, byokVaultErr := cryptopkg.DefaultBYOKVault()
-	if byokVaultErr != nil {
-		slog.Warn("BYOK vault unavailable — BYOK endpoints will fail", "err", byokVaultErr)
-	}
 	byokH := handlers.NewBYOKAgentHandler(pool, byokRepo, participants, byokVault)
 	mux.Handle("POST /api/v1/byok-agents", requireAuth(http.HandlerFunc(byokH.Create)))
 	mux.Handle("GET /api/v1/byok-agents", requireAuth(http.HandlerFunc(byokH.List)))

--- a/internal/config/byok_test.go
+++ b/internal/config/byok_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func validBYOKKEK() string {
+	return base64.StdEncoding.EncodeToString(make([]byte, 32))
+}
+
+func validBaseConfig() *Config {
+	return &Config{
+		DB:  DatabaseConfig{URL: "postgres://example"},
+		JWT: JWTConfig{Secret: "test-secret"},
+	}
+}
+
+func TestLoadBYOKFeatureFlag(t *testing.T) {
+	t.Run("valid key preserves legacy implicit enablement", func(t *testing.T) {
+		t.Setenv("BYOK_ENABLED", "")
+		t.Setenv("BYOK_KEK", validBYOKKEK())
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if !cfg.BYOK.Enabled || cfg.BYOK.ExplicitlyEnabled {
+			t.Fatalf("BYOK config = %#v, want implicitly enabled", cfg.BYOK)
+		}
+	})
+
+	t.Run("explicit false disables a configured key", func(t *testing.T) {
+		t.Setenv("BYOK_ENABLED", "false")
+		t.Setenv("BYOK_KEK", validBYOKKEK())
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.BYOK.Enabled || cfg.BYOK.ExplicitlyEnabled {
+			t.Fatalf("BYOK config = %#v, want disabled", cfg.BYOK)
+		}
+	})
+
+	t.Run("invalid flag is rejected", func(t *testing.T) {
+		t.Setenv("BYOK_ENABLED", "sometimes")
+		if _, err := Load(); err == nil || !strings.Contains(err.Error(), "BYOK_ENABLED") {
+			t.Fatalf("Load() error = %v, want BYOK_ENABLED error", err)
+		}
+	})
+}
+
+func TestValidateBYOKExplicitEnablement(t *testing.T) {
+	tests := []struct {
+		name string
+		kek  string
+	}{
+		{name: "missing key"},
+		{name: "malformed base64", kek: "not-base64"},
+		{name: "wrong key length", kek: base64.StdEncoding.EncodeToString([]byte("short"))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validBaseConfig()
+			cfg.BYOK = BYOKConfig{
+				Enabled:           true,
+				ExplicitlyEnabled: true,
+				KEK:               tt.kek,
+			}
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), "BYOK_KEK") {
+				t.Fatalf("Validate() error = %v, want BYOK_KEK error", err)
+			}
+		})
+	}
+
+	cfg := validBaseConfig()
+	cfg.BYOK = BYOKConfig{
+		Enabled:           true,
+		ExplicitlyEnabled: true,
+		KEK:               validBYOKKEK(),
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() with valid BYOK key error = %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/mail"
 	"os"
@@ -30,12 +31,24 @@ type Config struct {
 	Sports         SportsConfig
 	Auth           AuthConfig
 	Federation     FederationConfig
+	BYOK           BYOKConfig
 	// LoomDeployment names the Azure OpenAI deployment used by the
 	// @loom AI summon path specifically. Defaults to gpt-5.4-mini
 	// (cheap, fast — right tier for short summaries). Falls back to
 	// LLM.DeploymentName if unset, so a dev box configured for just
 	// one deployment doesn't need a second env var to enable Loom.
 	LoomDeployment string
+}
+
+// BYOKConfig controls bring-your-own-key agents. Enabled is the operator's
+// effective intent: a configured key enables the feature for backwards
+// compatibility unless BYOK_ENABLED is explicitly false. ExplicitlyEnabled
+// records BYOK_ENABLED=true so startup validation can fail fast instead of
+// silently disabling a feature the operator requested.
+type BYOKConfig struct {
+	Enabled           bool
+	ExplicitlyEnabled bool
+	KEK               string
 }
 
 // AuthConfig gates the cookie-auth migration. Phase 1.2 dual-issues
@@ -176,6 +189,16 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid FEDERATION_ENABLED: %w", err)
 	}
+	byokKEK := strings.TrimSpace(os.Getenv("BYOK_KEK"))
+	byokEnabled := byokKEK != ""
+	byokExplicitlyEnabled := false
+	if raw := strings.TrimSpace(os.Getenv("BYOK_ENABLED")); raw != "" {
+		byokEnabled, err = strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid BYOK_ENABLED: %w", err)
+		}
+		byokExplicitlyEnabled = byokEnabled
+	}
 
 	return &Config{
 		Environment: getEnv("ENVIRONMENT", "development"),
@@ -244,6 +267,11 @@ func Load() (*Config, error) {
 			CookieIssuance: getEnv("AUTH_COOKIE_ISSUANCE", "true") != "false",
 		},
 		Federation: FederationConfig{Enabled: federationEnabled},
+		BYOK: BYOKConfig{
+			Enabled:           byokEnabled,
+			ExplicitlyEnabled: byokExplicitlyEnabled,
+			KEK:               byokKEK,
+		},
 		Uploads: UploadsConfig{
 			Enabled: getEnv("UPLOADS_ENABLED", "") == "true",
 			ContentSafety: ContentSafetyConfig{
@@ -262,6 +290,11 @@ func (c *Config) Validate() error {
 	if c.DB.URL == "" {
 		return fmt.Errorf("DATABASE_URL is required")
 	}
+	if c.BYOK.ExplicitlyEnabled {
+		if err := validateBYOKKEK(c.BYOK.KEK); err != nil {
+			return err
+		}
+	}
 	if c.Email.SMTPHost != "" {
 		if c.Email.SMTPFrom == "" {
 			return fmt.Errorf("SMTP_FROM is required when SMTP_HOST is set")
@@ -278,6 +311,20 @@ func (c *Config) Validate() error {
 		}
 	} else if c.Email.SMTPUsername != "" || c.Email.SMTPPassword != "" || c.Email.SMTPFrom != "" {
 		return fmt.Errorf("SMTP_HOST is required when SMTP credentials or SMTP_FROM are set")
+	}
+	return nil
+}
+
+func validateBYOKKEK(encoded string) error {
+	if encoded == "" {
+		return fmt.Errorf("BYOK_KEK is required when BYOK_ENABLED=true")
+	}
+	key, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("BYOK_KEK must be valid base64: %w", err)
+	}
+	if len(key) != 32 {
+		return fmt.Errorf("BYOK_KEK must decode to 32 bytes, got %d", len(key))
 	}
 	return nil
 }

--- a/internal/crypto/byokvault.go
+++ b/internal/crypto/byokvault.go
@@ -9,8 +9,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
-	"sync"
 )
 
 // BYOKVault seals/opens BYOK API keys with AES-256-GCM using a key loaded
@@ -19,13 +17,9 @@ type BYOKVault struct {
 	gcm cipher.AEAD
 }
 
-var (
-	defaultVault   *BYOKVault
-	defaultVaultMu sync.Mutex
-)
-
-// NewBYOKVault builds a vault directly from a 32-byte key. Mostly used by
-// tests; production code should use DefaultBYOKVault which loads from env.
+// NewBYOKVault builds a vault directly from a 32-byte key. Callers using the
+// operator-facing configuration should prefer NewBYOKVaultFromBase64 after
+// validating the feature flag and key together.
 func NewBYOKVault(key []byte) (*BYOKVault, error) {
 	if len(key) != 32 {
 		return nil, fmt.Errorf("key must be 32 bytes, got %d", len(key))
@@ -41,35 +35,20 @@ func NewBYOKVault(key []byte) (*BYOKVault, error) {
 	return &BYOKVault{gcm: gcm}, nil
 }
 
-// DefaultBYOKVault returns a process-wide vault, initialized lazily from the
-// BYOK_KEK env var. Returns an error if the env var is missing or malformed.
-func DefaultBYOKVault() (*BYOKVault, error) {
-	defaultVaultMu.Lock()
-	defer defaultVaultMu.Unlock()
-	if defaultVault != nil {
-		return defaultVault, nil
-	}
-	raw := os.Getenv("BYOK_KEK")
-	if raw == "" {
+// NewBYOKVaultFromBase64 constructs a vault from the operator-facing
+// BYOK_KEK representation without reading process-global environment state.
+func NewBYOKVaultFromBase64(encoded string) (*BYOKVault, error) {
+	if encoded == "" {
 		return nil, errors.New("BYOK_KEK env var not set")
 	}
-	key, err := base64.StdEncoding.DecodeString(raw)
+	key, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return nil, fmt.Errorf("BYOK_KEK is not valid base64: %w", err)
 	}
 	if len(key) != 32 {
 		return nil, fmt.Errorf("BYOK_KEK must decode to 32 bytes, got %d", len(key))
 	}
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-	defaultVault = &BYOKVault{gcm: gcm}
-	return defaultVault, nil
+	return NewBYOKVault(key)
 }
 
 // Seal encrypts plaintext and returns a base64-encoded blob that packs

--- a/internal/crypto/byokvault_test.go
+++ b/internal/crypto/byokvault_test.go
@@ -65,3 +65,21 @@ func TestBYOKVault_Seal_EmptyRejected(t *testing.T) {
 		t.Fatal("expected empty plaintext to be rejected")
 	}
 }
+
+func TestNewBYOKVaultFromBase64RejectsInvalidKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "missing"},
+		{name: "malformed base64", key: "not-base64"},
+		{name: "wrong length", key: base64.StdEncoding.EncodeToString([]byte("short"))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := cryptopkg.NewBYOKVaultFromBase64(tt.key); err == nil {
+				t.Fatal("NewBYOKVaultFromBase64() error = nil, want rejection")
+			}
+		})
+	}
+}

--- a/scripts/check-production-compose.sh
+++ b/scripts/check-production-compose.sh
@@ -53,6 +53,8 @@ if ! jq -e \
     .services.web.build.args.SITE_URL == .services.web.environment.SITE_URL and
     .services.web.environment.API_URL == "http://api:8080" and
     .services.api.environment.UPLOADS_ENABLED == "true" and
+    .services.api.environment.BYOK_ENABLED != null and
+    .services.api.environment.BYOK_KEK != null and
     .services.postgres.healthcheck != null and
     .services.redis.healthcheck != null and
     (.services.api.healthcheck.test | join(" ") | contains("/readyz")) and

--- a/scripts/smoke-production-compose.sh
+++ b/scripts/smoke-production-compose.sh
@@ -4,6 +4,7 @@ set -eu
 project_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 compose_file="$project_dir/deployments/docker-compose.prod.yml"
 project_name=loomfeed-prod-smoke-$(date +%s)-$$
+response_file=$(mktemp)
 
 export POSTGRES_USER=${POSTGRES_USER:-loomfeed}
 export POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-prod_smoke_password}
@@ -18,6 +19,8 @@ export ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://127.0.0.1:$WEB_PORT}
 export SITE_URL=${SITE_URL:-http://127.0.0.1:$WEB_PORT}
 export UPLOADS_ENABLED=${UPLOADS_ENABLED:-true}
 export FEDERATION_ENABLED=true
+export BYOK_ENABLED=false
+export BYOK_KEK=
 
 compose() {
     docker compose --project-name "$project_name" --file "$compose_file" "$@"
@@ -31,6 +34,7 @@ cleanup() {
         compose logs --no-color >&2 || true
     fi
     compose down --volumes --remove-orphans --rmi local >/dev/null 2>&1 || true
+    rm -f "$response_file"
     exit "$exit_code"
 }
 trap cleanup EXIT HUP INT TERM
@@ -57,6 +61,14 @@ compose up --build --detach
 wait_for_url "API readiness" "http://127.0.0.1:$API_PORT/readyz"
 wait_for_url "web frontend" "http://127.0.0.1:$WEB_PORT/"
 wait_for_url "web-to-API rewrite" "http://127.0.0.1:$WEB_PORT/api/v1/config"
+runtime_config=$(curl --fail --silent --show-error \
+    "http://127.0.0.1:$WEB_PORT/api/v1/config")
+printf '%s' "$runtime_config" | jq -e '.byok_enabled == false' >/dev/null
+if compose run --rm --no-deps \
+    --env BYOK_ENABLED=true --env BYOK_KEK=not-base64 api >/dev/null 2>&1; then
+    echo "API accepted malformed BYOK_KEK while BYOK was explicitly enabled" >&2
+    exit 1
+fi
 
 system_identity_state=$(compose exec --no-TTY postgres psql \
     --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" --tuples-only \
@@ -134,6 +146,19 @@ registration=$(curl --fail --silent --show-error \
     "http://127.0.0.1:$WEB_PORT/api/v1/auth/register")
 access_token=$(printf '%s' "$registration" | jq -er '.access_token')
 participant_id=$(printf '%s' "$registration" | jq -er '.participant.id')
+
+byok_status=$(curl --silent --show-error --output "$response_file" \
+    --write-out '%{http_code}' \
+    --header 'Content-Type: application/json' \
+    --header "Authorization: Bearer $access_token" \
+    --data '{"display_name":"Unavailable BYOK","provider":"openai","model":"test","api_key":"secret"}' \
+    "http://127.0.0.1:$WEB_PORT/api/v1/byok-agents")
+if [ "$byok_status" != "503" ]; then
+    echo "expected disabled BYOK create to return 503; got $byok_status" >&2
+    cat "$response_file" >&2
+    exit 1
+fi
+jq -e '.error == "BYOK agents are not available on this server"' "$response_file" >/dev/null
 
 post_body=$(jq -n --arg community_id "$community_id" '{
     community_id: $community_id,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2,6 +2,7 @@
 
 import { setAuthHintCookie, clearAuthHintCookie } from "../lib/auth-hint";
 import { buildAgentDirectoryQuery, type AgentDirectoryParams } from "../lib/agent-directory";
+import type { ApiRuntimeConfig } from "./types";
 
 const BASE = "/api/v1";
 
@@ -161,7 +162,7 @@ export const api = {
     return request(`/people${s ? "?" + s : ""}`)
   },
   getSuggestedPeople: (limit = 10) => request(`/people/suggested?limit=${limit}`),
-  getConfig: () => request("/config"),
+  getConfig: () => request<ApiRuntimeConfig>("/config"),
   getFeed: (sort = "hot", limit = 25, offset = 0, type = "", cursor = "") =>
     request(`/feed?sort=${sort}&limit=${limit}&offset=${offset}${type ? `&type=${type}` : ''}${cursor ? `&cursor=${cursor}` : ''}`),
   getSubscribedFeed: (sort = "hot", limit = 25, offset = 0, type = "", cursor = "") =>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1,6 +1,14 @@
 // Shared types for API responses (camelCase, after snake_case transformation)
 // These match what the API returns after the client's transformKeys() runs.
 
+export interface ApiRuntimeConfig {
+  githubOauthEnabled: boolean
+  googleClientId: string
+  uploadsEnabled: boolean
+  federationEnabled: boolean
+  byokEnabled: boolean
+}
+
 export interface ProvenanceStats {
   postsCounted: number
   avgSourcesPerPost: number

--- a/web/src/components/BYOKAgentsSection.tsx
+++ b/web/src/components/BYOKAgentsSection.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { api } from '../api/client'
+import { isBYOKAvailable } from '../lib/byok-availability'
 
 interface BYOKAgent {
   id: string
@@ -22,6 +23,7 @@ const providerOptions = [
 export default function BYOKAgentsSection() {
   const [agents, setAgents] = useState<BYOKAgent[]>([])
   const [loading, setLoading] = useState(true)
+  const [byokEnabled, setBYOKEnabled] = useState<boolean | null>(null)
   const [showForm, setShowForm] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -33,18 +35,32 @@ export default function BYOKAgentsSection() {
   const [personaPrompt, setPersonaPrompt] = useState('')
   const [bio, setBio] = useState('')
 
-  const load = () => {
+  const load = useCallback(() => {
     setLoading(true)
     api
       .listBYOKAgents()
       .then((res: any) => setAgents(res?.agents || []))
       .catch(() => setAgents([]))
       .finally(() => setLoading(false))
-  }
+  }, [])
 
   useEffect(() => {
-    load()
-  }, [])
+    api
+      .getConfig()
+      .then((config) => {
+        const enabled = isBYOKAvailable(config)
+        setBYOKEnabled(enabled)
+        if (enabled) {
+          load()
+        } else {
+          setLoading(false)
+        }
+      })
+      .catch(() => {
+        setBYOKEnabled(false)
+        setLoading(false)
+      })
+  }, [load])
 
   const onProviderChange = (v: string) => {
     setProvider(v)
@@ -105,7 +121,7 @@ export default function BYOKAgentsSection() {
             Bring your own OpenAI, Anthropic, or Google key. We encrypt it and run the agent for you.
           </p>
         </div>
-        {!showForm && (
+        {byokEnabled === true && !showForm && (
           <button
             type="button"
             onClick={() => setShowForm(true)}
@@ -117,16 +133,24 @@ export default function BYOKAgentsSection() {
         )}
       </div>
 
-      {loading ? (
+      {loading || byokEnabled === null ? (
         <div className="lf-text-body-sm py-4 text-center" style={{ color: 'var(--lf-muted)' }}>
           Loading…
+        </div>
+      ) : byokEnabled === false ? (
+        <div
+          className="lf-text-body-sm rounded-lg p-4"
+          style={{ background: 'var(--lf-paper-alt)', color: 'var(--lf-muted)' }}
+        >
+          BYOK agents are not configured on this server. Ask the operator to
+          enable BYOK and provide a valid encryption key before adding an agent.
         </div>
       ) : agents.length === 0 && !showForm ? (
         <div
           className="lf-text-body-sm rounded-lg p-4 text-center"
           style={{ background: 'var(--lf-paper-alt)', color: 'var(--lf-muted)' }}
         >
-          No connected tools yet. Click <strong>+ New tool</strong> to create one.
+          No BYOK agents yet. Click <strong>+ New agent</strong> to create one.
         </div>
       ) : (
         <div className="flex flex-col gap-2">

--- a/web/src/lib/byok-availability.test.ts
+++ b/web/src/lib/byok-availability.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import type { ApiRuntimeConfig } from '../api/types'
+import { isBYOKAvailable } from './byok-availability'
+
+function runtimeConfig(byokEnabled: boolean): ApiRuntimeConfig {
+  return {
+    githubOauthEnabled: false,
+    googleClientId: '',
+    uploadsEnabled: false,
+    federationEnabled: false,
+    byokEnabled,
+  }
+}
+
+describe('isBYOKAvailable', () => {
+  it('uses the typed, camel-cased runtime-config capability', () => {
+    expect(isBYOKAvailable(runtimeConfig(true))).toBe(true)
+    expect(isBYOKAvailable(runtimeConfig(false))).toBe(false)
+  })
+})

--- a/web/src/lib/byok-availability.ts
+++ b/web/src/lib/byok-availability.ts
@@ -1,0 +1,5 @@
+import type { ApiRuntimeConfig } from '../api/types'
+
+export function isBYOKAvailable(config: ApiRuntimeConfig): boolean {
+  return config?.byokEnabled === true
+}


### PR DESCRIPTION
## Summary

- model BYOK enablement explicitly while preserving valid-key legacy behavior
- expose runtime availability and return a stable 503 from unavailable mutation routes
- disable and explain unavailable BYOK controls in the web UI with a typed config contract
- wire and document deployment configuration, startup validation, and production smoke coverage

## Validation

- `go test -race ./... -count=1`
- `go vet ./...`
- `npm test` (17 files, 47 tests)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- license, Docker context, Compose health, and production Compose static checks
- fresh-volume `scripts/smoke-production-compose.sh`
- two independent code reviews with zero remaining findings

Closes #47