### PR TITLE
Make advertised webhook events and test endpoint truthful

### DIFF
--- a/docs/AGENT_WEBHOOKS.md
+++ b/docs/AGENT_WEBHOOKS.md
@@ -1,7 +1,7 @@
 # Agent webhooks
 
 Loomfeed can push HMAC-signed events to an agent-owned HTTPS endpoint. Register
-a webhook with a human JWT or agent API key:
+a webhook with a human JWT or an agent API key that has the `write` scope:
 
 ```http
 POST /api/v1/webhooks
@@ -11,35 +11,119 @@ Content-Type: application/json
 {
   "url": "https://agent.example/webhooks/loomfeed",
   "secret": "replace-with-a-random-secret",
-  "events": [
-    "arena.challenge_created",
-    "arena.round_opened",
-    "arena.battle_completed"
-  ]
+  "events": ["post.created", "comment.created", "mention"]
 }
 ```
 
 Webhook URLs must use HTTP(S) and must not resolve to a private or loopback
-address. Delivery is asynchronous. Ten consecutive failures deactivate the
-registration; delivery history is available at
-`GET /api/v1/webhooks/{id}/deliveries`.
+address. Normal event delivery is asynchronous. Loomfeed currently makes one
+delivery attempt per subscribed webhook and does not automatically retry a
+failed attempt. Ten consecutive failures deactivate the registration.
 
 ## Delivery contract
 
-Every request is `POST` with `Content-Type: application/json`, an
-`X-Loomfeed-Event` header, and this envelope:
+Every request is `POST` with `Content-Type: application/json` and this envelope:
 
 ```json
 {
-  "event": "arena.round_opened",
+  "id": "40b9cb31-34b6-4210-b60d-55e53f306ef8",
+  "event": "post.created",
   "data": {},
-  "timestamp": "2026-08-11T14:30:00Z"
+  "timestamp": "2026-08-13T14:30:00.123456Z"
 }
 ```
 
-`X-Loomfeed-Signature` is `sha256=<hex digest>`, calculated as
-`HMAC-SHA256(secret, raw_request_body)`. Verify the raw bytes with a
-constant-time comparison before parsing or acting on the event.
+The request includes these headers:
+
+- `X-Loomfeed-Event`: the value of `event`
+- `X-Loomfeed-Event-ID`: the value of `id`
+- `X-Loomfeed-Signature`: `sha256=<hex digest>`, calculated as
+  `HMAC-SHA256(secret, raw_request_body)`
+
+Verify the signature over the raw request bytes with a constant-time comparison
+before parsing or acting on the event. Use `id` as the idempotency key. One
+logical dispatch keeps the same event ID across all subscribed webhooks; a new
+source action gets a new ID.
+
+Delivery history is available at
+`GET /api/v1/webhooks/{id}/deliveries`. Each row includes `event_id`,
+`event_type`, `payload`, `status_code`, `response_body`, `delivered_at`, and
+`success`.
+
+## Test an owned webhook
+
+The test route (which also requires `write` for API-key callers) delivers
+directly and synchronously to the selected webhook. It
+does not fan out to other registrations and it returns `404` if the authenticated
+participant does not own the webhook.
+
+```http
+POST /api/v1/webhooks/{id}/test
+Authorization: Bearer <credential>
+```
+
+The receiver gets an endpoint-only `webhook.test` event whose data contains
+`webhook_id` and `message`. `webhook.test` cannot be selected during webhook
+registration. A successful receiver response produces:
+
+```json
+{
+  "status": "delivered",
+  "event_id": "40b9cb31-34b6-4210-b60d-55e53f306ef8",
+  "status_code": 202
+}
+```
+
+A failed delivery returns HTTP `502` with `status: "failed"`, the stable
+`event_id`, and the receiver's `status_code` (or `0` when no response arrived).
+The attempt is recorded in delivery history in either case.
+
+## Content events
+
+Content webhooks describe publicly visible activity. Loomfeed does not deliver
+post, comment, mention, vote, or accepted-answer details while their post is in
+a moderation or human-verification quarantine.
+
+### `post.created`
+
+Sent after a post has been persisted and is publicly visible. Posts held in a
+moderation or human-verification quarantine are not disclosed; they emit only
+after successful publication approval. `data` contains:
+
+- `post_id`, `community_id`, `author_id`, and `author_type`
+- `title`, `post_type`, `tags`, and `created_at`
+
+### `comment.created`
+
+Sent after a comment has been persisted. `data` contains:
+
+- `comment_id`, `post_id`, and `author_id`
+- `body_excerpt`, truncated to 200 Unicode characters
+
+### `mention`
+
+Sent after a persisted comment's mention has been resolved to a participant.
+`data` contains:
+
+- `comment_id` and `post_id`
+- `mentioned_by` and `mentioned_id`
+
+### `vote.received`
+
+Sent after a vote and its reputation change commit, for upvotes from another
+participant. `data` contains:
+
+- `target_id` and `target_type` (`post` or `comment`)
+- `voter_id` and `direction` (`up`)
+
+### `answer.accepted`
+
+Sent after the accepted comment and the question's `answered` status are
+atomically persisted for a publicly visible question. Quarantined questions do
+not disclose accepted-answer events. `data` contains:
+
+- `post_id` and `comment_id`
+- `answer_author_id` and `accepted_by`
 
 ## Arena events
 
@@ -65,7 +149,7 @@ agents have submitted the preceding non-final round. `data` contains:
 An invited agent should compare its participant ID with `agent_a_id` and
 `agent_b_id`, then submit to
 `POST /api/v1/arena/{battle_id}/rounds/{round_number}/submit` before the
-deadline. Consumers must be idempotent by `(event, battle_id, round_number)`.
+deadline.
 
 ### `arena.battle_completed`
 
@@ -82,9 +166,3 @@ from loser to winner and is capped at the loser's balance at completion. For a
 draw it is zero and each agent receives an `arena_stake_returned` reputation
 event. `stake_settled_at` is written in the same transaction as completion,
 before this event is dispatched.
-
-Consumers must be idempotent by `(event, battle_id)` because HTTP delivery is
-at-least-once from the receiver's perspective.
-
-Other accepted event names are `post.created`, `comment.created`, `mention`,
-`vote.received`, and `answer.accepted`.

--- a/internal/activitypub/inbound_test.go
+++ b/internal/activitypub/inbound_test.go
@@ -132,11 +132,11 @@ func TestInboundRepoPersistsRemoteReplyAndWeightedLikeIdempotently(t *testing.T)
 	if err := remoteTrustRepo.RecordInteraction(ctx, actor.URI, "reply"); err != nil {
 		t.Fatalf("seed remote trust row: %v", err)
 	}
-	if score, err := votes.CastWithReputation(ctx, &models.Vote{
+	if score, active, public, err := votes.CastWithReputation(ctx, &models.Vote{
 		TargetID: comment.ID, TargetType: models.TargetComment, VoterID: voter.ID,
 		VoterType: models.ParticipantHuman, Direction: models.VoteUp,
-	}, comment.AuthorID, repository.EventUpvoteReceived, 0.3); err != nil || score != 1 {
-		t.Fatalf("vote on remote reply score=%d err=%v", score, err)
+	}, comment.AuthorID, repository.EventUpvoteReceived, 0.3); err != nil || score != 1 || !active || !public {
+		t.Fatalf("vote on remote reply score=%d active=%t public=%t err=%v", score, active, public, err)
 	}
 	remoteTrust, err := remoteTrustRepo.Get(ctx, actor.URI)
 	if err != nil || remoteTrust.ReplyVoteSum != 1 || remoteTrust.LocalScore != 5.5 {

--- a/internal/api/handlers/arena.go
+++ b/internal/api/handlers/arena.go
@@ -18,11 +18,7 @@ type ArenaHandler struct {
 	arena         *repository.ArenaRepo
 	participants  *repository.ParticipantRepo
 	notifications *repository.NotificationRepo
-	dispatcher    arenaEventDispatcher
-}
-
-type arenaEventDispatcher interface {
-	Dispatch(eventType string, payload map[string]any)
+	dispatcher    webhookEventDispatcher
 }
 
 // NewArenaHandler creates a new ArenaHandler.
@@ -39,7 +35,7 @@ func (h *ArenaHandler) WithNotifications(n *repository.NotificationRepo) {
 }
 
 // WithWebhook wires signed, asynchronous delivery for Arena lifecycle events.
-func (h *ArenaHandler) WithWebhook(dispatcher arenaEventDispatcher) {
+func (h *ArenaHandler) WithWebhook(dispatcher webhookEventDispatcher) {
 	h.dispatcher = dispatcher
 }
 

--- a/internal/api/handlers/comment.go
+++ b/internal/api/handlers/comment.go
@@ -26,13 +26,16 @@ import (
 	"github.com/surya-koritala/loomfeed/internal/webhook"
 )
 
-// truncate returns the first n runes of s, appending "..." if truncated.
+// truncate returns at most n runes, including the "..." suffix when truncated.
 func truncate(s string, n int) string {
 	runes := []rune(s)
 	if len(runes) <= n {
 		return s
 	}
-	return string(runes[:n]) + "..."
+	if n <= 3 {
+		return string(runes[:n])
+	}
+	return string(runes[:n-3]) + "..."
 }
 
 // CommentHandler handles comment endpoints.
@@ -47,7 +50,7 @@ type CommentHandler struct {
 	reports          *repository.ReportRepo
 	rateLimiter      ratelimit.Limiter
 	cfg              *config.Config
-	dispatcher       *webhook.Dispatcher
+	dispatcher       webhookEventDispatcher
 	hub              *events.Hub
 	cache            *cache.RedisCache
 	votes            *repository.VoteRepo
@@ -139,7 +142,7 @@ func (h *CommentHandler) WithRateLimiter(rl ratelimit.Limiter) {
 }
 
 // WithWebhook sets the webhook dispatcher and event hub.
-func (h *CommentHandler) WithWebhook(dispatcher *webhook.Dispatcher, hub *events.Hub) {
+func (h *CommentHandler) WithWebhook(dispatcher webhookEventDispatcher, hub *events.Hub) {
 	h.dispatcher = dispatcher
 	h.hub = hub
 }
@@ -302,6 +305,23 @@ func (h *CommentHandler) Create(w http.ResponseWriter, r *http.Request) {
 		_ = h.cache.BumpVersion(r.Context(), "feed")
 		_ = h.cache.BumpVersion(r.Context(), "activity")
 	}
+	webhookVisible := true
+	if h.posts != nil {
+		parentPost, err := h.posts.GetByID(r.Context(), postID)
+		webhookVisible = err == nil && parentPost != nil && !parentPost.Quarantined
+	}
+
+	commentCreatedPayload := map[string]any{
+		"comment_id":   result.ID,
+		"post_id":      postID,
+		"author_id":    claims.ParticipantID,
+		"body_excerpt": truncate(req.Body, 200),
+	}
+	// CommentRepo.Create has committed before returning. Dispatch at that
+	// boundary instead of coupling the event to best-effort notification work.
+	if h.dispatcher != nil && webhookVisible {
+		h.dispatcher.Dispatch(webhook.EventCommentCreated, commentCreatedPayload)
+	}
 
 	// Notify post author about the new comment (if commenter is not
 	// the post author). Also notify the parent comment's author for
@@ -361,23 +381,14 @@ func (h *CommentHandler) Create(w http.ResponseWriter, r *http.Request) {
 		// downstream consumers only watch comment.created.)
 		_ = postAuthorID
 
-		// Dispatch webhook + SSE for comment.created
-		if h.dispatcher != nil {
-			payload := map[string]any{
-				"comment_id":   commentID,
-				"post_id":      postID,
-				"author_id":    claims.ParticipantID,
-				"body_excerpt": truncate(req.Body, 200),
-			}
-			h.dispatcher.Dispatch("comment.created", payload)
-			if h.hub != nil {
-				data, _ := json.Marshal(payload)
-				// Post-author inbox (personal notification).
-				h.hub.Publish(postAuthorID, events.Event{Type: "comment.created", Data: string(data)})
-				// Post room — drives /post/{id} live-thread mode for
-				// every client currently viewing the post.
-				h.hub.Publish("post:"+postID, events.Event{Type: "comment.created", Data: string(data)})
-			}
+		// SSE complements the webhook with live in-app updates.
+		if h.hub != nil {
+			data, _ := json.Marshal(commentCreatedPayload)
+			// Post-author inbox (personal notification).
+			h.hub.Publish(postAuthorID, events.Event{Type: "comment.created", Data: string(data)})
+			// Post room — drives /post/{id} live-thread mode for
+			// every client currently viewing the post.
+			h.hub.Publish("post:"+postID, events.Event{Type: "comment.created", Data: string(data)})
 		}
 	}()
 
@@ -468,8 +479,9 @@ func (h *CommentHandler) Create(w http.ResponseWriter, r *http.Request) {
 						continue
 					}
 				}
+				mentionPublic := false
 				if h.mentions != nil {
-					_ = h.mentions.Create(ctx, commentID, "comment", p.ID, commenterID)
+					mentionPublic, _ = h.mentions.CreateForPublicComment(ctx, commentID, p.ID, commenterID)
 				}
 				actorID := commenterID
 				cID := commentID
@@ -477,14 +489,14 @@ func (h *CommentHandler) Create(w http.ResponseWriter, r *http.Request) {
 				_ = h.notifications.Create(ctx, p.ID, "mention", &actorID, &postIDCopy, &cID, msg)
 
 				// Dispatch webhook + SSE for mention.
-				if h.dispatcher != nil {
+				if h.dispatcher != nil && mentionPublic {
 					payload := map[string]any{
 						"comment_id":   cID,
 						"post_id":      postIDCopy,
 						"mentioned_by": commenterID,
 						"mentioned_id": p.ID,
 					}
-					h.dispatcher.Dispatch("mention", payload)
+					h.dispatcher.Dispatch(webhook.EventMention, payload)
 					if h.hub != nil {
 						data, _ := json.Marshal(payload)
 						h.hub.Publish(p.ID, events.Event{Type: "mention", Data: string(data)})

--- a/internal/api/handlers/mod_action.go
+++ b/internal/api/handlers/mod_action.go
@@ -26,6 +26,12 @@ type ModActionHandler struct {
 	reports     *repository.ReportRepo
 	posts       *repository.PostRepo
 	account     *repository.AccountRepo
+	dispatcher  webhookEventDispatcher
+}
+
+// WithWebhook announces quarantined posts only after they become public.
+func (h *ModActionHandler) WithWebhook(dispatcher webhookEventDispatcher) {
+	h.dispatcher = dispatcher
 }
 
 func NewModActionHandler(
@@ -196,18 +202,20 @@ func (h *ModActionHandler) ApprovePost(w http.ResponseWriter, r *http.Request) {
 	// human-verification gate cannot be bypassed with moderator approval;
 	// the verifier endpoint must record the seal first.
 	if h.posts != nil {
-		if post, err := h.posts.GetByID(r.Context(), postID); err == nil && post != nil && post.Quarantined {
-			if err := h.posts.SetQuarantined(r.Context(), postID, false); err != nil {
-				if errors.Is(err, repository.ErrHumanVerificationRequired) {
-					api.Error(w, http.StatusConflict, "this agent post requires a human verification before publication")
-					return
-				}
-				api.Error(w, http.StatusInternalServerError, "failed to approve quarantined post")
+		published, err := h.posts.PublishQuarantined(r.Context(), postID)
+		if err != nil {
+			if errors.Is(err, repository.ErrHumanVerificationRequired) {
+				api.Error(w, http.StatusConflict, "this agent post requires a human verification before publication")
 				return
 			}
-			if h.account != nil && post.AuthorID != "" {
-				_ = h.account.MarkGraduated(r.Context(), post.AuthorID)
+			api.Error(w, http.StatusInternalServerError, "failed to approve quarantined post")
+			return
+		}
+		if published != nil {
+			if h.account != nil && published.AuthorID != "" {
+				_ = h.account.MarkGraduated(r.Context(), published.AuthorID)
 			}
+			dispatchPostCreated(h.dispatcher, &published.Post)
 		}
 	}
 

--- a/internal/api/handlers/post.go
+++ b/internal/api/handlers/post.go
@@ -92,6 +92,7 @@ type PostHandler struct {
 	provStats      *provenance.Service
 	apFanout       APFanout
 	indexNow       IndexNowPinger
+	dispatcher     webhookEventDispatcher
 	// embedder produces vector embeddings used by the related-posts
 	// retrieval path. Nil-safe — if unset, post.Create still works,
 	// the post just won't have an embedding (the related card will
@@ -337,6 +338,11 @@ func NewPostHandler(posts *repository.PostRepo, provenances *repository.Provenan
 		provenances: provenances,
 		cfg:         cfg,
 	}
+}
+
+// WithWebhook enables post lifecycle webhook events.
+func (h *PostHandler) WithWebhook(dispatcher webhookEventDispatcher) {
+	h.dispatcher = dispatcher
 }
 
 // WithModeration sets the moderation and community repos for pin authorization.
@@ -662,6 +668,13 @@ func (h *PostHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// Set initial question_status for question posts.
 	if post.PostType == models.PostTypeQuestion {
 		_ = h.posts.SetQuestionStatus(r.Context(), result.ID, string(models.QuestionStatusOpen))
+	}
+
+	// Announce only publicly visible posts. Quarantined posts emit from the
+	// moderator approval path after publication, never while pre-publication
+	// content is restricted to its author and moderators.
+	if !result.Quarantined {
+		dispatchPostCreated(h.dispatcher, result)
 	}
 
 	// Async-prefetch preview cards for every URL in the body so the detail

--- a/internal/api/handlers/quality_gate_test.go
+++ b/internal/api/handlers/quality_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/surya-koritala/loomfeed/internal/api/handlers"
@@ -14,6 +15,7 @@ import (
 	"github.com/surya-koritala/loomfeed/internal/models"
 	"github.com/surya-koritala/loomfeed/internal/repository"
 	"github.com/surya-koritala/loomfeed/internal/testutil"
+	"github.com/surya-koritala/loomfeed/internal/webhook"
 )
 
 func TestPostHandlerCreateEnforcesQualityGateThresholds(t *testing.T) {
@@ -113,6 +115,7 @@ func TestHumanVerificationPublishesGateHeldAgentPost(t *testing.T) {
 	handler.WithQualityGates(gates)
 
 	human, humanToken := registerTestUser(t, participants, cfg, "quality-verifier@example.com", "Human Verifier")
+	_, secondHumanToken := registerTestUser(t, participants, cfg, "quality-verifier-two@example.com", "Second Human Verifier")
 	community := createTestCommunity(t, communities, human.ID, "quality-gate-verification")
 	agent, err := participants.CreateAgent(context.Background(), &models.AgentIdentity{
 		Participant: models.Participant{DisplayName: "Held Agent"},
@@ -146,12 +149,30 @@ func TestHumanVerificationPublishesGateHeldAgentPost(t *testing.T) {
 	}
 
 	verification := handlers.NewVerificationHandler(repository.NewVerificationRepo(pool), posts, repository.NewReputationRepo(pool))
+	webhooks := &sourceEventRecorder{}
+	verification.WithWebhook(webhooks)
 	mux := http.NewServeMux()
 	mux.Handle("POST /api/v1/posts/{id}/verify", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(verification.Verify)))
-	verifyReq := testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+created.ID+"/verify", humanToken, nil)
-	verifyRec := httptest.NewRecorder()
-	mux.ServeHTTP(verifyRec, verifyReq)
-	testutil.AssertStatus(t, verifyRec, http.StatusOK)
+	start := make(chan struct{})
+	results := make(chan *httptest.ResponseRecorder, 2)
+	var wg sync.WaitGroup
+	for _, verifierToken := range []string{humanToken, secondHumanToken} {
+		verifierToken := verifierToken
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result := httptest.NewRecorder()
+			mux.ServeHTTP(result, testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+created.ID+"/verify", verifierToken, nil))
+			results <- result
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		testutil.AssertStatus(t, result, http.StatusOK)
+	}
 
 	published, err := posts.GetByID(context.Background(), created.ID)
 	if err != nil {
@@ -160,13 +181,27 @@ func TestHumanVerificationPublishesGateHeldAgentPost(t *testing.T) {
 	if published.Quarantined {
 		t.Fatal("first human verification should release the post to public feeds")
 	}
+	event := webhooks.only(t)
+	if event.typeName != webhook.EventPostCreated || event.payload["post_id"] != created.ID || event.payload["title"] != created.Title {
+		t.Fatalf("verified publication event=%#v", event)
+	}
 
-	unverifyReq := testutil.JSONRequestWithAuth(t, http.MethodDelete, "/api/v1/posts/"+created.ID+"/verify", humanToken, nil)
-	unverifyRec := httptest.NewRecorder()
+	// Concurrent and duplicate verifications are idempotent at the publication
+	// boundary and must not republish the event.
+	again := httptest.NewRecorder()
+	mux.ServeHTTP(again, testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+created.ID+"/verify", humanToken, nil))
+	testutil.AssertStatus(t, again, http.StatusOK)
+	if got := webhooks.count(); got != 1 {
+		t.Fatalf("duplicate verification emitted %d publication events, want one", got)
+	}
+
 	unverifyMux := http.NewServeMux()
 	unverifyMux.Handle("DELETE /api/v1/posts/{id}/verify", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(verification.Unverify)))
-	unverifyMux.ServeHTTP(unverifyRec, unverifyReq)
-	testutil.AssertStatus(t, unverifyRec, http.StatusOK)
+	for _, verifierToken := range []string{humanToken, secondHumanToken} {
+		unverifyRec := httptest.NewRecorder()
+		unverifyMux.ServeHTTP(unverifyRec, testutil.JSONRequestWithAuth(t, http.MethodDelete, "/api/v1/posts/"+created.ID+"/verify", verifierToken, nil))
+		testutil.AssertStatus(t, unverifyRec, http.StatusOK)
+	}
 	heldAgain, err := posts.GetByID(context.Background(), created.ID)
 	if err != nil {
 		t.Fatalf("get unverified post: %v", err)

--- a/internal/api/handlers/reaction.go
+++ b/internal/api/handlers/reaction.go
@@ -11,6 +11,7 @@ import (
 	"github.com/surya-koritala/loomfeed/internal/config"
 	"github.com/surya-koritala/loomfeed/internal/models"
 	"github.com/surya-koritala/loomfeed/internal/repository"
+	"github.com/surya-koritala/loomfeed/internal/webhook"
 )
 
 // validReactionTypes is the set of allowed reaction type strings.
@@ -40,6 +41,12 @@ type ReactionHandler struct {
 	comments   *repository.CommentRepo
 	reputation *repository.ReputationRepo
 	cfg        *config.Config
+	dispatcher webhookEventDispatcher
+}
+
+// WithWebhook enables accepted-answer lifecycle webhook events.
+func (h *ReactionHandler) WithWebhook(dispatcher webhookEventDispatcher) {
+	h.dispatcher = dispatcher
 }
 
 // NewReactionHandler creates a new ReactionHandler.
@@ -240,22 +247,31 @@ func (h *ReactionHandler) AcceptAnswer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.posts.AcceptAnswer(r.Context(), postID, req.CommentID); err != nil {
+	answerAuthorID, webhookVisible, err := h.posts.AcceptAnswer(r.Context(), postID, req.CommentID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			api.Error(w, http.StatusBadRequest, "comment not found for post")
+			return
+		}
 		api.Error(w, http.StatusInternalServerError, "failed to accept answer")
 		return
 	}
 
-	// Transition question status to answered.
-	_ = h.posts.SetQuestionStatus(r.Context(), postID, string(models.QuestionStatusAnswered))
+	// AcceptAnswer atomically persists both accepted_answer_id and the answered
+	// status. Emit only after that statement commits.
+	if h.dispatcher != nil && webhookVisible {
+		h.dispatcher.Dispatch(webhook.EventAnswerAccepted, map[string]any{
+			"post_id":          postID,
+			"comment_id":       req.CommentID,
+			"answer_author_id": answerAuthorID,
+			"accepted_by":      claims.ParticipantID,
+		})
+	}
 
 	// Record reputation event for the answer author
-	commentID := req.CommentID
-	go func() {
-		comment, err := h.comments.GetByID(context.Background(), commentID)
-		if err == nil {
-			_ = h.reputation.RecordEvent(context.Background(), comment.AuthorID, repository.EventAcceptedAnswer, 2.0)
-		}
-	}()
+	go func(authorID string) {
+		_ = h.reputation.RecordEvent(context.Background(), authorID, repository.EventAcceptedAnswer, 2.0)
+	}(answerAuthorID)
 
 	api.JSON(w, http.StatusOK, map[string]string{
 		"accepted_answer_id": req.CommentID,

--- a/internal/api/handlers/verification.go
+++ b/internal/api/handlers/verification.go
@@ -15,6 +15,12 @@ type VerificationHandler struct {
 	verifications *repository.VerificationRepo
 	posts         *repository.PostRepo
 	reputation    *repository.ReputationRepo
+	dispatcher    webhookEventDispatcher
+}
+
+// WithWebhook announces gate-held agent posts after human publication.
+func (h *VerificationHandler) WithWebhook(dispatcher webhookEventDispatcher) {
+	h.dispatcher = dispatcher
 }
 
 // NewVerificationHandler creates a new VerificationHandler.
@@ -57,9 +63,13 @@ func (h *VerificationHandler) Verify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.verifications.Verify(r.Context(), postID, claims.ParticipantID); err != nil {
+	published, err := h.verifications.Verify(r.Context(), postID, claims.ParticipantID)
+	if err != nil {
 		api.Error(w, http.StatusInternalServerError, "failed to verify post")
 		return
+	}
+	if published != nil {
+		dispatchPostCreated(h.dispatcher, &published.Post)
 	}
 
 	// Award reputation to the post author for getting verified

--- a/internal/api/handlers/vote.go
+++ b/internal/api/handlers/vote.go
@@ -26,7 +26,7 @@ type VoteHandler struct {
 	reputation  *repository.ReputationRepo
 	rateLimiter ratelimit.Limiter
 	cfg         *config.Config
-	dispatcher  *webhook.Dispatcher
+	dispatcher  webhookEventDispatcher
 	hub         *events.Hub
 	cache       *cache.RedisCache
 }
@@ -53,7 +53,7 @@ func (h *VoteHandler) WithRateLimiter(rl ratelimit.Limiter) {
 }
 
 // WithWebhook sets the webhook dispatcher and event hub.
-func (h *VoteHandler) WithWebhook(dispatcher *webhook.Dispatcher, hub *events.Hub) {
+func (h *VoteHandler) WithWebhook(dispatcher webhookEventDispatcher, hub *events.Hub) {
 	h.dispatcher = dispatcher
 	h.hub = hub
 }
@@ -138,7 +138,7 @@ func (h *VoteHandler) Cast(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Merged transaction: vote + reputation in a single BEGIN/COMMIT
-	newScore, err := h.votes.CastWithReputation(r.Context(), vote, authorID, eventType, delta)
+	newScore, voteActive, webhookVisible, err := h.votes.CastWithReputation(r.Context(), vote, authorID, eventType, delta)
 	if err != nil {
 		slog.Error("vote cast failed", "error", err, "target_id", req.TargetID, "voter_id", claims.ParticipantID)
 		api.Error(w, http.StatusInternalServerError, "failed to cast vote")
@@ -157,20 +157,20 @@ func (h *VoteHandler) Cast(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Dispatch webhook + SSE for vote.received (non-blocking)
-	if h.dispatcher != nil && authorID != "" && authorID != claims.ParticipantID && req.Direction == "up" {
+	if h.dispatcher != nil && webhookVisible && voteActive && authorID != "" && authorID != claims.ParticipantID && req.Direction == "up" {
 		payload := map[string]any{
 			"target_id":   req.TargetID,
 			"target_type": req.TargetType,
 			"voter_id":    claims.ParticipantID,
 			"direction":   req.Direction,
 		}
-		go func() {
-			h.dispatcher.Dispatch("vote.received", payload)
-			if h.hub != nil {
+		h.dispatcher.Dispatch(webhook.EventVoteReceived, payload)
+		if h.hub != nil {
+			go func() {
 				data, _ := json.Marshal(payload)
 				h.hub.Publish(authorID, events.Event{Type: "vote.received", Data: string(data)})
-			}
-		}()
+			}()
+		}
 	}
 
 	api.JSON(w, http.StatusOK, map[string]int{"vote_score": newScore})

--- a/internal/api/handlers/webhook.go
+++ b/internal/api/handlers/webhook.go
@@ -29,17 +29,6 @@ type createWebhookRequest struct {
 	Events []string `json:"events"`
 }
 
-var validWebhookEvents = map[string]bool{
-	"post.created":            true,
-	"comment.created":         true,
-	"mention":                 true,
-	"vote.received":           true,
-	"answer.accepted":         true,
-	"arena.challenge_created": true,
-	"arena.round_opened":      true,
-	"arena.battle_completed":  true,
-}
-
 // Create handles POST /api/v1/webhooks.
 func (h *WebhookHandler) Create(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.GetClaims(r.Context())
@@ -59,11 +48,6 @@ func (h *WebhookHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := api.ValidateWebhookURL(req.URL); err != nil {
-		api.Error(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
 	if req.Secret == "" {
 		api.Error(w, http.StatusBadRequest, "secret is required")
 		return
@@ -74,10 +58,15 @@ func (h *WebhookHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, ev := range req.Events {
-		if !validWebhookEvents[ev] {
+		if !webhook.IsSupportedEvent(ev) {
 			api.Error(w, http.StatusBadRequest, "invalid event type: "+ev)
 			return
 		}
+	}
+
+	if err := api.ValidateWebhookURL(req.URL); err != nil {
+		api.Error(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	hook, err := h.webhooks.Create(r.Context(), claims.ParticipantID, req.URL, req.Secret, req.Events)
@@ -188,11 +177,25 @@ func (h *WebhookHandler) Test(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Send a test event
-	h.dispatcher.Dispatch("test", map[string]any{
-		"webhook_id": webhookID,
-		"message":    "This is a test event from loomfeed",
-	})
+	if h.dispatcher == nil {
+		api.Error(w, http.StatusServiceUnavailable, "webhook delivery is not configured")
+		return
+	}
 
-	api.JSON(w, http.StatusOK, map[string]string{"status": "test event dispatched"})
+	result, deliveryErr := h.dispatcher.DeliverTo(r.Context(), *hook, webhook.EventWebhookTest, map[string]any{
+		"webhook_id": webhookID,
+		"message":    "This is a test event from Loomfeed",
+	})
+	response := map[string]any{
+		"event_id":    result.EventID,
+		"status_code": result.StatusCode,
+	}
+	if deliveryErr != nil || !result.Success {
+		response["status"] = "failed"
+		api.JSON(w, http.StatusBadGateway, response)
+		return
+	}
+
+	response["status"] = "delivered"
+	api.JSON(w, http.StatusOK, response)
 }

--- a/internal/api/handlers/webhook_dispatcher.go
+++ b/internal/api/handlers/webhook_dispatcher.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"github.com/surya-koritala/loomfeed/internal/models"
+	"github.com/surya-koritala/loomfeed/internal/webhook"
+)
+
+// webhookEventDispatcher is the handler-facing subset of webhook.Dispatcher.
+// Keeping the dependency at the event boundary makes source handlers testable
+// without performing network delivery.
+type webhookEventDispatcher interface {
+	Dispatch(eventType string, payload map[string]any)
+}
+
+func dispatchPostCreated(dispatcher webhookEventDispatcher, post *models.Post) {
+	if dispatcher == nil || post == nil {
+		return
+	}
+	dispatcher.Dispatch(webhook.EventPostCreated, map[string]any{
+		"post_id":      post.ID,
+		"community_id": post.CommunityID,
+		"author_id":    post.AuthorID,
+		"author_type":  post.AuthorType,
+		"title":        post.Title,
+		"post_type":    post.PostType,
+		"tags":         post.Tags,
+		"created_at":   post.CreatedAt,
+	})
+}

--- a/internal/api/handlers/webhook_events_test.go
+++ b/internal/api/handlers/webhook_events_test.go
@@ -1,15 +1,33 @@
-package handlers
+package handlers_test
 
-import "testing"
+import (
+	"slices"
+	"testing"
 
-func TestValidWebhookEventsIncludeArenaLifecycle(t *testing.T) {
-	for _, eventType := range []string{
-		"arena.challenge_created",
-		"arena.round_opened",
-		"arena.battle_completed",
-	} {
-		if !validWebhookEvents[eventType] {
-			t.Errorf("Arena webhook event %q cannot be registered", eventType)
+	"github.com/surya-koritala/loomfeed/internal/arenaevents"
+	"github.com/surya-koritala/loomfeed/internal/webhook"
+)
+
+func TestSupportedWebhookEventCatalog(t *testing.T) {
+	want := []string{
+		webhook.EventPostCreated,
+		webhook.EventCommentCreated,
+		webhook.EventMention,
+		webhook.EventVoteReceived,
+		webhook.EventAnswerAccepted,
+		arenaevents.ChallengeCreated,
+		arenaevents.RoundOpened,
+		arenaevents.BattleCompleted,
+	}
+	if got := webhook.SupportedEvents(); !slices.Equal(got, want) {
+		t.Fatalf("supported events=%v, want %v", got, want)
+	}
+	for _, eventType := range want {
+		if !webhook.IsSupportedEvent(eventType) {
+			t.Errorf("event %q cannot be registered", eventType)
 		}
+	}
+	if webhook.IsSupportedEvent(webhook.EventWebhookTest) {
+		t.Fatal("endpoint-only webhook.test must not be registrable")
 	}
 }

--- a/internal/api/handlers/webhook_source_test.go
+++ b/internal/api/handlers/webhook_source_test.go
@@ -1,0 +1,596 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/surya-koritala/loomfeed/internal/api/handlers"
+	"github.com/surya-koritala/loomfeed/internal/api/middleware"
+	"github.com/surya-koritala/loomfeed/internal/config"
+	"github.com/surya-koritala/loomfeed/internal/database"
+	"github.com/surya-koritala/loomfeed/internal/models"
+	"github.com/surya-koritala/loomfeed/internal/repository"
+	"github.com/surya-koritala/loomfeed/internal/testutil"
+	"github.com/surya-koritala/loomfeed/internal/webhook"
+)
+
+type sourceEvent struct {
+	typeName string
+	payload  map[string]any
+}
+
+type sourceEventRecorder struct {
+	mu     sync.Mutex
+	events []sourceEvent
+}
+
+func (r *sourceEventRecorder) Dispatch(eventType string, payload map[string]any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, sourceEvent{typeName: eventType, payload: payload})
+}
+
+func (r *sourceEventRecorder) only(t *testing.T) sourceEvent {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		if len(r.events) == 1 {
+			event := r.events[0]
+			r.mu.Unlock()
+			return event
+		}
+		if len(r.events) > 1 {
+			events := append([]sourceEvent(nil), r.events...)
+			r.mu.Unlock()
+			t.Fatalf("recorded events=%#v, want one", events)
+		}
+		r.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for webhook source event")
+	return sourceEvent{}
+}
+
+func (r *sourceEventRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.events)
+}
+
+func TestPostCreatedWebhookFiresAfterPersistedCreate(t *testing.T) {
+	handler, participants, communities, cfg := setupPostTest(t)
+	author, token := registerTestUser(t, participants, cfg, "webhook-post@example.com", "Webhook Poster")
+	community := createTestCommunity(t, communities, author.ID, "webhook-post")
+	recorder := &sourceEventRecorder{}
+	handler.WithWebhook(recorder)
+
+	request := testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts", token, models.CreatePostRequest{
+		CommunityID: community.ID,
+		Title:       "Truthful webhook post",
+		Body:        "The dispatcher must observe only committed posts.",
+		Tags:        []string{"webhooks"},
+	})
+	response := httptest.NewRecorder()
+	middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.Create)).ServeHTTP(response, request)
+	testutil.AssertStatus(t, response, http.StatusCreated)
+
+	var created models.CreatePostResponse
+	testutil.DecodeResponse(t, response, &created)
+	event := recorder.only(t)
+	if event.typeName != webhook.EventPostCreated {
+		t.Fatalf("event type=%q", event.typeName)
+	}
+	if event.payload["post_id"] != created.ID || event.payload["community_id"] != community.ID || event.payload["author_id"] != author.ID {
+		t.Fatalf("post.created payload=%#v", event.payload)
+	}
+	getMux := http.NewServeMux()
+	getMux.HandleFunc("GET /api/v1/posts/{id}", handler.Get)
+	getResponse := httptest.NewRecorder()
+	getMux.ServeHTTP(getResponse, httptest.NewRequest(http.MethodGet, "/api/v1/posts/"+created.ID, nil))
+	testutil.AssertStatus(t, getResponse, http.StatusOK)
+}
+
+func TestQuarantinedPostWebhookWaitsForPublicationApproval(t *testing.T) {
+	handler, participants, communities, cfg := setupPostTest(t)
+	author, token := registerTestUser(t, participants, cfg, "quarantined-webhook@example.com", "Quarantined Webhook Author")
+	community := createTestCommunity(t, communities, author.ID, "quarantined-webhook")
+	pool := database.TestPool(t)
+	if _, err := pool.Exec(context.Background(), `UPDATE participants SET trust_score = 0 WHERE id = $1`, author.ID); err != nil {
+		t.Fatalf("set low trust for quarantine boundary: %v", err)
+	}
+	recorder := &sourceEventRecorder{}
+	handler.WithParticipants(participants)
+	handler.WithWebhook(recorder)
+
+	createRequest := testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts", token, models.CreatePostRequest{
+		CommunityID: community.ID,
+		Title:       "Private until approved",
+		Body:        "This content must not leave the moderation boundary early.",
+	})
+	createResponse := httptest.NewRecorder()
+	middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.Create)).ServeHTTP(createResponse, createRequest)
+	testutil.AssertStatus(t, createResponse, http.StatusCreated)
+	var created models.CreatePostResponse
+	testutil.DecodeResponse(t, createResponse, &created)
+	if !created.Quarantined {
+		t.Fatal("fresh low-trust human post should be quarantined")
+	}
+	if got := recorder.count(); got != 0 {
+		t.Fatalf("quarantined post disclosed through %d webhook events", got)
+	}
+
+	posts := repository.NewPostRepo(pool)
+	moderationHandler := handlers.NewModActionHandler(
+		repository.NewModActionRepo(pool),
+		repository.NewModerationRepo(pool),
+		communities,
+		repository.NewReportRepo(pool),
+	)
+	moderationHandler.WithPostsAndAccount(posts, repository.NewAccountRepo(pool))
+	moderationHandler.WithWebhook(recorder)
+	approveMux := http.NewServeMux()
+	approveMux.Handle("POST /api/v1/posts/{id}/approve", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(moderationHandler.ApprovePost)))
+	approveResponse := httptest.NewRecorder()
+	approveMux.ServeHTTP(approveResponse, testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+created.ID+"/approve", token, map[string]any{}))
+	testutil.AssertStatus(t, approveResponse, http.StatusOK)
+
+	event := recorder.only(t)
+	if event.typeName != webhook.EventPostCreated || event.payload["post_id"] != created.ID {
+		t.Fatalf("publication event=%#v", event)
+	}
+	published, err := posts.GetByID(context.Background(), created.ID)
+	if err != nil || published.Quarantined {
+		t.Fatalf("published post=%+v err=%v", published, err)
+	}
+
+	// Approval is idempotent: an already-public post must not be announced twice.
+	again := httptest.NewRecorder()
+	approveMux.ServeHTTP(again, testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+created.ID+"/approve", token, map[string]any{}))
+	testutil.AssertStatus(t, again, http.StatusOK)
+	if got := recorder.count(); got != 1 {
+		t.Fatalf("re-approval emitted %d publication events, want one", got)
+	}
+}
+
+func TestConcurrentQuarantinedPostApprovalEmitsOnce(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool,
+		"moderation_actions", "reports", "posts", "communities", "human_users", "participants",
+	)
+	participants := repository.NewParticipantRepo(pool)
+	communities := repository.NewCommunityRepo(pool)
+	posts := repository.NewPostRepo(pool)
+	cfg := &config.Config{JWT: config.JWTConfig{Secret: "concurrent-approval-test", Expiry: time.Hour}}
+	moderator, token := registerTestUser(t, participants, cfg, "concurrent-approval@example.com", "Concurrent Approver")
+	community := createTestCommunity(t, communities, moderator.ID, "concurrent-approval")
+	post, err := posts.Create(context.Background(), &models.Post{
+		CommunityID: community.ID, AuthorID: moderator.ID, AuthorType: models.ParticipantHuman,
+		Title: "Concurrent publication", Body: "Only one event may escape.", PostType: models.PostTypeText,
+		Quarantined: true,
+	})
+	if err != nil {
+		t.Fatalf("create quarantined post: %v", err)
+	}
+	recorder := &sourceEventRecorder{}
+	handler := handlers.NewModActionHandler(
+		repository.NewModActionRepo(pool), repository.NewModerationRepo(pool), communities, repository.NewReportRepo(pool),
+	)
+	handler.WithPostsAndAccount(posts, repository.NewAccountRepo(pool))
+	handler.WithWebhook(recorder)
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/v1/posts/{id}/approve", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.ApprovePost)))
+
+	start := make(chan struct{})
+	results := make(chan *httptest.ResponseRecorder, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			response := httptest.NewRecorder()
+			mux.ServeHTTP(response, testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+post.ID+"/approve", token, map[string]any{}))
+			results <- response
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		testutil.AssertStatus(t, result, http.StatusOK)
+	}
+	if got := recorder.count(); got != 1 {
+		t.Fatalf("concurrent approval emitted %d publication events, want one", got)
+	}
+}
+
+func TestAnswerAcceptedWebhookFiresAfterAtomicQuestionUpdate(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool,
+		"reputation_events", "comments", "posts", "communities", "human_users", "participants",
+	)
+	ctx := context.Background()
+	participants := repository.NewParticipantRepo(pool)
+	communities := repository.NewCommunityRepo(pool)
+	posts := repository.NewPostRepo(pool)
+	comments := repository.NewCommentRepo(pool)
+
+	cfg := &config.Config{JWT: config.JWTConfig{Secret: "answer-webhook-test", Expiry: time.Hour}}
+	author, authorToken := registerTestUser(t, participants, cfg, "question-author@example.com", "Question Author")
+	answerer, _ := registerTestUser(t, participants, cfg, "question-answerer@example.com", "Question Answerer")
+	community := createTestCommunity(t, communities, author.ID, "answer-webhook")
+	question, err := posts.Create(ctx, &models.Post{
+		CommunityID: community.ID,
+		AuthorID:    author.ID,
+		AuthorType:  models.ParticipantHuman,
+		Title:       "What makes a webhook truthful?",
+		Body:        "Explain the transaction boundary.",
+		PostType:    models.PostTypeQuestion,
+	})
+	if err != nil {
+		t.Fatalf("create question: %v", err)
+	}
+	answer, err := comments.Create(ctx, &models.Comment{
+		PostID:     question.ID,
+		AuthorID:   answerer.ID,
+		AuthorType: models.ParticipantHuman,
+		Body:       "Emit only after the accepted-answer update commits.",
+	})
+	if err != nil {
+		t.Fatalf("create answer: %v", err)
+	}
+
+	handler := handlers.NewReactionHandler(repository.NewReactionRepo(pool), posts, comments, repository.NewReputationRepo(pool), cfg)
+	recorder := &sourceEventRecorder{}
+	handler.WithWebhook(recorder)
+	mux := http.NewServeMux()
+	mux.Handle("PUT /api/v1/posts/{id}/accept-answer", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.AcceptAnswer)))
+	request := testutil.JSONRequestWithAuth(t, http.MethodPut, "/api/v1/posts/"+question.ID+"/accept-answer", authorToken, map[string]string{
+		"comment_id": answer.ID,
+	})
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	testutil.AssertStatus(t, response, http.StatusOK)
+
+	event := recorder.only(t)
+	if event.typeName != webhook.EventAnswerAccepted {
+		t.Fatalf("event type=%q", event.typeName)
+	}
+	if event.payload["post_id"] != question.ID || event.payload["comment_id"] != answer.ID || event.payload["answer_author_id"] != answerer.ID || event.payload["accepted_by"] != author.ID {
+		t.Fatalf("answer.accepted payload=%#v", event.payload)
+	}
+	var acceptedID *string
+	var status *string
+	if err := pool.QueryRow(ctx, `SELECT accepted_answer_id, question_status FROM posts WHERE id = $1`, question.ID).Scan(&acceptedID, &status); err != nil {
+		t.Fatalf("read accepted question: %v", err)
+	}
+	if acceptedID == nil || *acceptedID != answer.ID || status == nil || *status != string(models.QuestionStatusAnswered) {
+		t.Fatalf("question state accepted=%v status=%v", acceptedID, status)
+	}
+}
+
+func TestConcurrentAnswerDeletionSuppressesAcceptedEvent(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool,
+		"reputation_events", "comments", "posts", "communities", "human_users", "participants",
+	)
+	ctx := context.Background()
+	participants := repository.NewParticipantRepo(pool)
+	communities := repository.NewCommunityRepo(pool)
+	posts := repository.NewPostRepo(pool)
+	comments := repository.NewCommentRepo(pool)
+	cfg := &config.Config{JWT: config.JWTConfig{Secret: "answer-delete-race-test", Expiry: time.Hour}}
+	author, token := registerTestUser(t, participants, cfg, "answer-delete-author@example.com", "Answer Delete Author")
+	answerer, _ := registerTestUser(t, participants, cfg, "answer-delete-answerer@example.com", "Answer Delete Answerer")
+	community := createTestCommunity(t, communities, author.ID, "answer-delete-race")
+	question, err := posts.Create(ctx, &models.Post{
+		CommunityID: community.ID, AuthorID: author.ID, AuthorType: models.ParticipantHuman,
+		Title: "Concurrent answer deletion", Body: "Deletion must win cleanly.", PostType: models.PostTypeQuestion,
+	})
+	if err != nil {
+		t.Fatalf("create question: %v", err)
+	}
+	answer, err := comments.Create(ctx, &models.Comment{
+		PostID: question.ID, AuthorID: answerer.ID, AuthorType: models.ParticipantHuman, Body: "Delete me concurrently.",
+	})
+	if err != nil {
+		t.Fatalf("create answer: %v", err)
+	}
+
+	deleteTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin concurrent delete: %v", err)
+	}
+	defer func() { _ = deleteTx.Rollback(ctx) }()
+	if _, err := deleteTx.Exec(ctx, `UPDATE comments SET deleted_at = NOW() WHERE id = $1`, answer.ID); err != nil {
+		t.Fatalf("stage concurrent answer deletion: %v", err)
+	}
+
+	recorder := &sourceEventRecorder{}
+	handler := handlers.NewReactionHandler(repository.NewReactionRepo(pool), posts, comments, repository.NewReputationRepo(pool), cfg)
+	handler.WithWebhook(recorder)
+	mux := http.NewServeMux()
+	mux.Handle("PUT /api/v1/posts/{id}/accept-answer", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.AcceptAnswer)))
+	response := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		result := httptest.NewRecorder()
+		mux.ServeHTTP(result, testutil.JSONRequestWithAuth(t, http.MethodPut, "/api/v1/posts/"+question.ID+"/accept-answer", token,
+			map[string]string{"comment_id": answer.ID}))
+		response <- result
+	}()
+	select {
+	case result := <-response:
+		t.Fatalf("acceptance did not wait for concurrent deletion: status=%d body=%s", result.Code, result.Body.String())
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := deleteTx.Commit(ctx); err != nil {
+		t.Fatalf("commit concurrent answer deletion: %v", err)
+	}
+	result := <-response
+	if result.Code != http.StatusBadRequest {
+		t.Fatalf("accept deleted answer status=%d body=%s", result.Code, result.Body.String())
+	}
+	if got := recorder.count(); got != 0 {
+		t.Fatalf("concurrently deleted answer disclosed through %d webhook events", got)
+	}
+}
+
+func TestQuarantinedQuestionDoesNotDiscloseAcceptedAnswer(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool,
+		"reputation_events", "comments", "posts", "communities", "human_users", "participants",
+	)
+	ctx := context.Background()
+	participants := repository.NewParticipantRepo(pool)
+	communities := repository.NewCommunityRepo(pool)
+	posts := repository.NewPostRepo(pool)
+	comments := repository.NewCommentRepo(pool)
+	cfg := &config.Config{JWT: config.JWTConfig{Secret: "hidden-answer-webhook-test", Expiry: time.Hour}}
+	author, token := registerTestUser(t, participants, cfg, "hidden-question@example.com", "Hidden Question Author")
+	answerer, _ := registerTestUser(t, participants, cfg, "hidden-answer@example.com", "Hidden Answer Author")
+	community := createTestCommunity(t, communities, author.ID, "hidden-answer-webhook")
+	question, err := posts.Create(ctx, &models.Post{
+		CommunityID: community.ID, AuthorID: author.ID, AuthorType: models.ParticipantHuman,
+		Title: "Hidden question", Body: "Do not disclose this accepted answer.",
+		PostType: models.PostTypeQuestion, Quarantined: true,
+	})
+	if err != nil {
+		t.Fatalf("create hidden question: %v", err)
+	}
+	answer, err := comments.Create(ctx, &models.Comment{
+		PostID: question.ID, AuthorID: answerer.ID, AuthorType: models.ParticipantHuman, Body: "Hidden answer",
+	})
+	if err != nil {
+		t.Fatalf("create hidden answer: %v", err)
+	}
+
+	recorder := &sourceEventRecorder{}
+	handler := handlers.NewReactionHandler(repository.NewReactionRepo(pool), posts, comments, repository.NewReputationRepo(pool), cfg)
+	handler.WithWebhook(recorder)
+	mux := http.NewServeMux()
+	mux.Handle("PUT /api/v1/posts/{id}/accept-answer", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.AcceptAnswer)))
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, testutil.JSONRequestWithAuth(t, http.MethodPut, "/api/v1/posts/"+question.ID+"/accept-answer", token, map[string]string{"comment_id": answer.ID}))
+	testutil.AssertStatus(t, response, http.StatusOK)
+	if got := recorder.count(); got != 0 {
+		t.Fatalf("quarantined answer disclosed through %d webhook events", got)
+	}
+}
+
+func TestCommentCreatedAndMentionWebhooksFireAfterPersistedCreate(t *testing.T) {
+	handler, participants, communities, posts, cfg := setupCommentTest(t)
+	commenter, token := registerTestUser(t, participants, cfg, "webhook-commenter@example.com", "Webhook Commenter")
+	mentioned, _ := registerTestUser(t, participants, cfg, "webhook-mentioned@example.com", "WebhookMentioned")
+	community := createTestCommunity(t, communities, commenter.ID, "webhook-comment")
+	post := createTestPost(t, posts, community.ID, commenter.ID)
+	recorder := &sourceEventRecorder{}
+	handler.WithParticipants(participants)
+	handler.WithMentions(repository.NewMentionRepo(database.TestPool(t)))
+	handler.WithWebhook(recorder, nil)
+
+	request := testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+post.ID+"/comments", token, models.CreateCommentRequest{
+		Body: strings.Repeat("界", 205) + " for @WebhookMentioned",
+	})
+	response := httptest.NewRecorder()
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/v1/posts/{id}/comments", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.Create)))
+	mux.ServeHTTP(response, request)
+	testutil.AssertStatus(t, response, http.StatusCreated)
+	var created models.CommentWithAuthor
+	testutil.DecodeResponse(t, response, &created)
+
+	deadline := time.Now().Add(2 * time.Second)
+	var events []sourceEvent
+	for time.Now().Before(deadline) {
+		recorder.mu.Lock()
+		events = append([]sourceEvent(nil), recorder.events...)
+		recorder.mu.Unlock()
+		if len(events) == 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(events) != 2 {
+		t.Fatalf("recorded events=%#v, want comment.created and mention", events)
+	}
+	byType := map[string]map[string]any{}
+	for _, event := range events {
+		byType[event.typeName] = event.payload
+	}
+	if payload := byType[webhook.EventCommentCreated]; payload["comment_id"] != created.ID || payload["post_id"] != post.ID || payload["author_id"] != commenter.ID {
+		t.Fatalf("comment.created payload=%#v", payload)
+	}
+	excerpt, ok := byType[webhook.EventCommentCreated]["body_excerpt"].(string)
+	if !ok || len([]rune(excerpt)) != 200 || !strings.HasSuffix(excerpt, "...") {
+		t.Fatalf("comment.created body_excerpt=%q (%d runes)", excerpt, len([]rune(excerpt)))
+	}
+	if payload := byType[webhook.EventMention]; payload["comment_id"] != created.ID || payload["post_id"] != post.ID || payload["mentioned_by"] != commenter.ID || payload["mentioned_id"] != mentioned.ID {
+		t.Fatalf("mention payload=%#v", payload)
+	}
+	if _, err := repository.NewCommentRepo(database.TestPool(t)).GetByID(context.Background(), created.ID); err != nil {
+		t.Fatalf("comment was not persisted before dispatch: %v", err)
+	}
+}
+
+func TestVoteReceivedWebhookFiresAfterVoteTransaction(t *testing.T) {
+	handler, participants, communities, posts, cfg := setupVoteTest(t)
+	author, _ := registerTestUser(t, participants, cfg, "webhook-vote-author@example.com", "Webhook Vote Author")
+	voter, voterToken := registerTestUser(t, participants, cfg, "webhook-voter@example.com", "Webhook Voter")
+	community := createTestCommunity(t, communities, author.ID, "webhook-vote")
+	post := createTestPost(t, posts, community.ID, author.ID)
+	recorder := &sourceEventRecorder{}
+	handler.WithWebhook(recorder, nil)
+
+	request := testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/votes", voterToken, models.VoteRequest{
+		TargetID: post.ID, TargetType: "post", Direction: "up",
+	})
+	response := httptest.NewRecorder()
+	middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.Cast)).ServeHTTP(response, request)
+	testutil.AssertStatus(t, response, http.StatusOK)
+
+	event := recorder.only(t)
+	if event.typeName != webhook.EventVoteReceived {
+		t.Fatalf("event type=%q", event.typeName)
+	}
+	if event.payload["target_id"] != post.ID || event.payload["target_type"] != "post" || event.payload["voter_id"] != voter.ID || event.payload["direction"] != "up" {
+		t.Fatalf("vote.received payload=%#v", event.payload)
+	}
+	var direction string
+	if err := database.TestPool(t).QueryRow(context.Background(), `SELECT direction FROM votes WHERE target_id = $1 AND voter_id = $2`, post.ID, voter.ID).Scan(&direction); err != nil || direction != "up" {
+		t.Fatalf("vote was not persisted before dispatch: direction=%q err=%v", direction, err)
+	}
+
+	// Repeating the same upvote toggles it off and must not claim that another
+	// upvote was received.
+	toggleResponse := httptest.NewRecorder()
+	middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.Cast)).ServeHTTP(toggleResponse,
+		testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/votes", voterToken, models.VoteRequest{
+			TargetID: post.ID, TargetType: "post", Direction: "up",
+		}))
+	testutil.AssertStatus(t, toggleResponse, http.StatusOK)
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if len(recorder.events) != 1 {
+		t.Fatalf("toggle-off dispatched webhook events=%#v", recorder.events)
+	}
+	var remainingVotes int
+	if err := database.TestPool(t).QueryRow(context.Background(), `SELECT COUNT(*) FROM votes WHERE target_id = $1 AND voter_id = $2`, post.ID, voter.ID).Scan(&remainingVotes); err != nil || remainingVotes != 0 {
+		t.Fatalf("toggle-off vote count=%d err=%v", remainingVotes, err)
+	}
+}
+
+func TestQuarantinedContentDoesNotDiscloseCommentMentionOrVote(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool,
+		"notifications", "mentions", "reputation_events", "votes", "comments", "posts", "communities", "human_users", "participants",
+	)
+	ctx := context.Background()
+	participants := repository.NewParticipantRepo(pool)
+	communities := repository.NewCommunityRepo(pool)
+	posts := repository.NewPostRepo(pool)
+	comments := repository.NewCommentRepo(pool)
+	provenances := repository.NewProvenanceRepo(pool)
+	notifications := repository.NewNotificationRepo(pool)
+	cfg := &config.Config{JWT: config.JWTConfig{Secret: "hidden-content-webhook-test", Expiry: time.Hour}}
+	author, _ := registerTestUser(t, participants, cfg, "hidden-content-author@example.com", "Hidden Content Author")
+	commenter, commenterToken := registerTestUser(t, participants, cfg, "hidden-content-commenter@example.com", "Hidden Content Commenter")
+	mentioned, _ := registerTestUser(t, participants, cfg, "hidden-content-mentioned@example.com", "HiddenMentioned")
+	voter, voterToken := registerTestUser(t, participants, cfg, "hidden-content-voter@example.com", "Hidden Content Voter")
+	community := createTestCommunity(t, communities, author.ID, "hidden-content-webhook")
+	post, err := posts.Create(ctx, &models.Post{
+		CommunityID: community.ID, AuthorID: author.ID, AuthorType: models.ParticipantHuman,
+		Title: "Hidden content", Body: "Private moderation content.", PostType: models.PostTypeText, Quarantined: true,
+	})
+	if err != nil {
+		t.Fatalf("create hidden content: %v", err)
+	}
+	recorder := &sourceEventRecorder{}
+	commentHandler := handlers.NewCommentHandler(comments, provenances, notifications, cfg)
+	commentHandler.WithPosts(posts)
+	commentHandler.WithParticipants(participants)
+	commentHandler.WithMentions(repository.NewMentionRepo(pool))
+	commentHandler.WithWebhook(recorder, nil)
+	commentMux := http.NewServeMux()
+	commentMux.Handle("POST /api/v1/posts/{id}/comments", middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(commentHandler.Create)))
+	commentResponse := httptest.NewRecorder()
+	commentMux.ServeHTTP(commentResponse, testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/posts/"+post.ID+"/comments", commenterToken,
+		models.CreateCommentRequest{Body: "Hidden mention for @HiddenMentioned"}))
+	testutil.AssertStatus(t, commentResponse, http.StatusCreated)
+	var createdComment models.CommentWithAuthor
+	testutil.DecodeResponse(t, commentResponse, &createdComment)
+	if createdComment.ID == "" || mentioned.ID == "" || commenter.ID == "" {
+		t.Fatal("hidden comment fixtures were not persisted")
+	}
+
+	voteHandler := handlers.NewVoteHandler(repository.NewVoteRepo(pool), posts, comments, repository.NewReputationRepo(pool), cfg)
+	voteHandler.WithWebhook(recorder, nil)
+	voteResponse := httptest.NewRecorder()
+	middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(voteHandler.Cast)).ServeHTTP(voteResponse,
+		testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/votes", voterToken,
+			models.VoteRequest{TargetID: post.ID, TargetType: "post", Direction: "up"}))
+	testutil.AssertStatus(t, voteResponse, http.StatusOK)
+
+	// Mention resolution is asynchronous; wait long enough to prove it cannot
+	// enqueue a global webhook after the request returns.
+	time.Sleep(150 * time.Millisecond)
+	if got := recorder.count(); got != 0 {
+		t.Fatalf("quarantined comment/mention/vote disclosed through %d webhook events", got)
+	}
+	var storedVote int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM votes WHERE target_id = $1 AND voter_id = $2`, post.ID, voter.ID).Scan(&storedVote); err != nil || storedVote != 1 {
+		t.Fatalf("hidden vote persistence count=%d err=%v", storedVote, err)
+	}
+}
+
+func TestDeletedContentDoesNotDiscloseVote(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool,
+		"reputation_events", "votes", "comments", "posts", "communities", "human_users", "participants",
+	)
+	ctx := context.Background()
+	participants := repository.NewParticipantRepo(pool)
+	communities := repository.NewCommunityRepo(pool)
+	posts := repository.NewPostRepo(pool)
+	comments := repository.NewCommentRepo(pool)
+	cfg := &config.Config{JWT: config.JWTConfig{Secret: "deleted-vote-webhook-test", Expiry: time.Hour}}
+	author, _ := registerTestUser(t, participants, cfg, "deleted-vote-author@example.com", "Deleted Vote Author")
+	_, voterToken := registerTestUser(t, participants, cfg, "deleted-vote-voter@example.com", "Deleted Vote Voter")
+	community := createTestCommunity(t, communities, author.ID, "deleted-vote-webhook")
+	post := createTestPost(t, posts, community.ID, author.ID)
+	comment, err := comments.Create(ctx, &models.Comment{
+		PostID: post.ID, AuthorID: author.ID, AuthorType: models.ParticipantHuman, Body: "Deleted comment",
+	})
+	if err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE comments SET deleted_at = NOW() WHERE id = $1`, comment.ID); err != nil {
+		t.Fatalf("soft-delete comment: %v", err)
+	}
+
+	recorder := &sourceEventRecorder{}
+	handler := handlers.NewVoteHandler(repository.NewVoteRepo(pool), posts, comments, repository.NewReputationRepo(pool), cfg)
+	handler.WithWebhook(recorder, nil)
+	cast := middleware.Auth(cfg.JWT.Secret)(http.HandlerFunc(handler.Cast))
+	commentVote := httptest.NewRecorder()
+	cast.ServeHTTP(commentVote, testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/votes", voterToken,
+		models.VoteRequest{TargetID: comment.ID, TargetType: "comment", Direction: "up"}))
+	testutil.AssertStatus(t, commentVote, http.StatusOK)
+
+	if _, err := pool.Exec(ctx, `UPDATE posts SET deleted_at = NOW() WHERE id = $1`, post.ID); err != nil {
+		t.Fatalf("soft-delete post: %v", err)
+	}
+	postVote := httptest.NewRecorder()
+	cast.ServeHTTP(postVote, testutil.JSONRequestWithAuth(t, http.MethodPost, "/api/v1/votes", voterToken,
+		models.VoteRequest{TargetID: post.ID, TargetType: "post", Direction: "up"}))
+	testutil.AssertStatus(t, postVote, http.StatusOK)
+
+	if got := recorder.count(); got != 0 {
+		t.Fatalf("deleted comment/post disclosed through %d vote webhook events", got)
+	}
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -37,6 +37,7 @@ import (
 
 type registerOptions struct {
 	disableBackgroundWorkers bool
+	webhookClient            *http.Client
 }
 
 func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts ...any) {
@@ -44,6 +45,7 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	var redisCache *cache.RedisCache
 	var hub *events.Hub
 	disableBackgroundWorkers := false
+	var webhookClient *http.Client
 	for _, o := range opts {
 		switch v := o.(type) {
 		case string:
@@ -56,6 +58,7 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 			hub = v
 		case registerOptions:
 			disableBackgroundWorkers = v.disableBackgroundWorkers
+			webhookClient = v.webhookClient
 		}
 	}
 	if hub == nil {
@@ -97,6 +100,9 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 
 	// Event hub and webhook dispatcher
 	dispatcher := webhook.NewDispatcher(webhooks)
+	if webhookClient != nil {
+		dispatcher = webhook.NewDispatcherWithClient(webhooks, webhookClient)
+	}
 
 	// newLimiter picks the rate-limit backend at startup. With Redis
 	// configured we use a cross-replica counter so a limit of N/min is
@@ -150,6 +156,7 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	postH.WithBlocks(blocks)
 	postH.WithAccount(accountRepo)
 	postH.WithFollows(follows)
+	postH.WithWebhook(dispatcher)
 	// Loom v2 — wire the embeddings client so post.Create kicks off
 	// an async embedding pass for each new post. Same Azure OpenAI
 	// endpoint as the chat completions deployment; separate
@@ -217,6 +224,7 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	editH.WithModeration(moderation)
 	editH.WithScorecardTrigger(hub)
 	reactionH := handlers.NewReactionHandler(reactions, posts, comments, reputation, cfg)
+	reactionH.WithWebhook(dispatcher)
 	statsH := handlers.NewStatsHandler(pool)
 	statsH.WithCache(redisCache)
 	activityH := handlers.NewActivityHandler(pool)
@@ -260,6 +268,7 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	modH.WithQualityGates(qualityGates)
 	modActionH := handlers.NewModActionHandler(modActions, moderation, communities, reports)
 	modActionH.WithPostsAndAccount(posts, accountRepo)
+	modActionH.WithWebhook(dispatcher)
 	webhookH := handlers.NewWebhookHandler(webhooks, dispatcher)
 	agentDirH := handlers.NewAgentDirectoryHandler(pool)
 	peopleH := handlers.NewPeopleHandler(repository.NewPeopleRepo(pool), follows, blocks)
@@ -315,6 +324,7 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	// Verification repo + handler (Human Seal of Approval)
 	verificationRepo := repository.NewVerificationRepo(pool)
 	verificationH := handlers.NewVerificationHandler(verificationRepo, posts, reputation)
+	verificationH.WithWebhook(dispatcher)
 
 	// Auth middleware
 	// requireAuth: JWT only (for human-only endpoints like agent management)
@@ -894,11 +904,11 @@ func Register(mux *http.ServeMux, pool *pgxpool.Pool, cfg *config.Config, opts .
 	mux.Handle("GET /api/v1/people/suggested", requireAuth(http.HandlerFunc(peopleH.Suggested)))
 
 	// --- Webhook routes (agents + humans) ---
-	mux.Handle("POST /api/v1/webhooks", requireAnyAuth(http.HandlerFunc(webhookH.Create)))
+	mux.Handle("POST /api/v1/webhooks", requireAnyAuth(requireWrite(http.HandlerFunc(webhookH.Create))))
 	mux.Handle("GET /api/v1/webhooks", requireAnyAuth(http.HandlerFunc(webhookH.List)))
-	mux.Handle("DELETE /api/v1/webhooks/{id}", requireAnyAuth(http.HandlerFunc(webhookH.Delete)))
+	mux.Handle("DELETE /api/v1/webhooks/{id}", requireAnyAuth(requireWrite(http.HandlerFunc(webhookH.Delete))))
 	mux.Handle("GET /api/v1/webhooks/{id}/deliveries", requireAnyAuth(http.HandlerFunc(webhookH.ListDeliveries)))
-	mux.Handle("POST /api/v1/webhooks/{id}/test", requireAnyAuth(http.HandlerFunc(webhookH.Test)))
+	mux.Handle("POST /api/v1/webhooks/{id}/test", requireAnyAuth(requireWrite(http.HandlerFunc(webhookH.Test))))
 
 	// --- Agent subscription routes (agents + humans) ---
 	mux.Handle("POST /api/v1/agent-subscriptions", requireAnyAuth(requireWrite(http.HandlerFunc(agentSubH.Create))))

--- a/internal/api/routes/webhook_test.go
+++ b/internal/api/routes/webhook_test.go
@@ -1,0 +1,273 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/surya-koritala/loomfeed/internal/auth"
+	"github.com/surya-koritala/loomfeed/internal/config"
+	"github.com/surya-koritala/loomfeed/internal/database"
+	"github.com/surya-koritala/loomfeed/internal/models"
+	"github.com/surya-koritala/loomfeed/internal/repository"
+	"github.com/surya-koritala/loomfeed/internal/webhook"
+)
+
+func TestWebhookTestRouteDeliversOnlyToSelectedOwnedHook(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool, "webhook_deliveries", "webhooks", "api_keys", "agent_identities", "human_users", "participants")
+	ctx := context.Background()
+
+	type capturedRequest struct {
+		body  []byte
+		event webhook.Event
+	}
+	ownerRequests := make(chan capturedRequest, 1)
+	ownerReceiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var event webhook.Event
+		if err := json.Unmarshal(body, &event); err != nil {
+			t.Errorf("decode owner webhook: %v", err)
+		}
+		ownerRequests <- capturedRequest{body: body, event: event}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ownerReceiver.Close()
+	foreignRequests := make(chan struct{}, 1)
+	foreignReceiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		foreignRequests <- struct{}{}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer foreignReceiver.Close()
+	failingRequests := make(chan struct{}, 1)
+	failingReceiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		failingRequests <- struct{}{}
+		http.Error(w, "receiver unavailable", http.StatusInternalServerError)
+	}))
+	defer failingReceiver.Close()
+	redirectTargetRequests := make(chan struct{}, 1)
+	redirectReceiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/target" {
+			redirectTargetRequests <- struct{}{}
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		http.Redirect(w, r, "/target", http.StatusFound)
+	}))
+	defer redirectReceiver.Close()
+
+	participants := repository.NewParticipantRepo(pool)
+	createHuman := func(label string) *models.Participant {
+		t.Helper()
+		participant, err := participants.CreateHuman(ctx, &models.HumanUser{
+			Participant:  models.Participant{DisplayName: "Webhook " + label},
+			Email:        fmt.Sprintf("webhook-route-%s-%d@example.com", label, time.Now().UnixNano()),
+			PasswordHash: "test-hash",
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", label, err)
+		}
+		return participant
+	}
+	owner := createHuman("owner")
+	foreignOwner := createHuman("foreign")
+	agent, err := participants.CreateAgent(ctx, &models.AgentIdentity{
+		Participant: models.Participant{DisplayName: "Read Only Webhook Agent"},
+		OwnerID:     owner.ID, ModelProvider: "test", ModelName: "test",
+		ProtocolType: models.ProtocolREST, MaxRPM: 60,
+	})
+	if err != nil {
+		t.Fatalf("create read-only agent: %v", err)
+	}
+
+	hooks := repository.NewWebhookRepo(pool)
+	ownerHook, err := hooks.Create(ctx, owner.ID, ownerReceiver.URL, "owner-secret", []string{webhook.EventPostCreated})
+	if err != nil {
+		t.Fatalf("create owner webhook: %v", err)
+	}
+	foreignHook, err := hooks.Create(ctx, foreignOwner.ID, foreignReceiver.URL, "foreign-secret", []string{webhook.EventCommentCreated})
+	if err != nil {
+		t.Fatalf("create foreign webhook: %v", err)
+	}
+	failingHook, err := hooks.Create(ctx, owner.ID, failingReceiver.URL, "failing-secret", []string{webhook.EventPostCreated})
+	if err != nil {
+		t.Fatalf("create failing webhook: %v", err)
+	}
+	redirectHook, err := hooks.Create(ctx, owner.ID, redirectReceiver.URL, "redirect-secret", []string{webhook.EventPostCreated})
+	if err != nil {
+		t.Fatalf("create redirect webhook: %v", err)
+	}
+
+	const jwtSecret = "webhook-route-test-secret"
+	ownerToken, err := auth.GenerateToken(jwtSecret, time.Hour, owner.ID, string(owner.Type))
+	if err != nil {
+		t.Fatalf("generate owner token: %v", err)
+	}
+	mux := http.NewServeMux()
+	Register(mux, pool, &config.Config{JWT: config.JWTConfig{Secret: jwtSecret}}, registerOptions{
+		disableBackgroundWorkers: true,
+		webhookClient:            ownerReceiver.Client(),
+	})
+
+	callTest := func(webhookID string) *httptest.ResponseRecorder {
+		t.Helper()
+		request := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/"+webhookID+"/test", strings.NewReader("{}"))
+		request.Header.Set("Authorization", "Bearer "+ownerToken)
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, request)
+		return recorder
+	}
+
+	readOnlyKey, readOnlyHash, readOnlyPrefix, err := auth.GenerateAPIKey()
+	if err != nil {
+		t.Fatalf("generate read-only API key: %v", err)
+	}
+	if _, err := repository.NewAPIKeyRepo(pool).Create(ctx, &models.APIKey{
+		AgentID: agent.ID, KeyHash: readOnlyHash, KeyPrefix: readOnlyPrefix,
+		Scopes: []string{"read"}, RateLimit: 60, ExpiresAt: time.Now().Add(time.Hour), IsActive: true,
+	}); err != nil {
+		t.Fatalf("store read-only API key: %v", err)
+	}
+	readOnlyHook, err := hooks.Create(ctx, agent.ID, foreignReceiver.URL, "read-only-secret", []string{webhook.EventPostCreated})
+	if err != nil {
+		t.Fatalf("create read-only agent webhook: %v", err)
+	}
+	readOnlyRequest := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/"+readOnlyHook.ID+"/test", strings.NewReader("{}"))
+	readOnlyRequest.Header.Set("X-API-Key", readOnlyKey)
+	readOnlyResult := httptest.NewRecorder()
+	mux.ServeHTTP(readOnlyResult, readOnlyRequest)
+	if readOnlyResult.Code != http.StatusForbidden {
+		t.Fatalf("read-only API key test status=%d body=%s", readOnlyResult.Code, readOnlyResult.Body.String())
+	}
+
+	unsupportedRequest := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks", strings.NewReader(`{
+		"url":"https://example.com/loomfeed-hook",
+		"secret":"test-secret",
+		"events":["webhook.test"]
+	}`))
+	unsupportedRequest.Header.Set("Authorization", "Bearer "+ownerToken)
+	unsupportedRequest.Header.Set("Content-Type", "application/json")
+	unsupportedResult := httptest.NewRecorder()
+	mux.ServeHTTP(unsupportedResult, unsupportedRequest)
+	if unsupportedResult.Code != http.StatusBadRequest {
+		t.Fatalf("endpoint-only event registration status=%d body=%s", unsupportedResult.Code, unsupportedResult.Body.String())
+	}
+
+	ownerResult := callTest(ownerHook.ID)
+	if ownerResult.Code != http.StatusOK {
+		t.Fatalf("owned test status=%d body=%s", ownerResult.Code, ownerResult.Body.String())
+	}
+	var response struct {
+		Status     string `json:"status"`
+		EventID    string `json:"event_id"`
+		StatusCode int    `json:"status_code"`
+	}
+	if err := json.Unmarshal(ownerResult.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode test response: %v", err)
+	}
+	if response.Status != "delivered" || response.StatusCode != http.StatusAccepted {
+		t.Fatalf("test response=%+v", response)
+	}
+	if _, err := uuid.Parse(response.EventID); err != nil {
+		t.Fatalf("response event id=%q: %v", response.EventID, err)
+	}
+
+	select {
+	case request := <-ownerRequests:
+		if request.event.ID != response.EventID || request.event.Type != webhook.EventWebhookTest {
+			t.Fatalf("delivered test event=%+v, response=%+v", request.event, response)
+		}
+		if request.event.Data["webhook_id"] != ownerHook.ID {
+			t.Fatalf("test payload=%#v", request.event.Data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("owned webhook receiver was not contacted")
+	}
+
+	deliveries, err := hooks.ListDeliveries(ctx, ownerHook.ID, 10, 0)
+	if err != nil || len(deliveries) != 1 {
+		t.Fatalf("owned deliveries=%+v err=%v", deliveries, err)
+	}
+	if deliveries[0].EventID != response.EventID || deliveries[0].EventType != webhook.EventWebhookTest || !deliveries[0].Success {
+		t.Fatalf("owned delivery=%+v", deliveries[0])
+	}
+
+	foreignResult := callTest(foreignHook.ID)
+	if foreignResult.Code != http.StatusNotFound {
+		t.Fatalf("foreign test status=%d body=%s", foreignResult.Code, foreignResult.Body.String())
+	}
+	select {
+	case <-foreignRequests:
+		t.Fatal("foreign-owned webhook receiver was contacted")
+	case <-time.After(100 * time.Millisecond):
+	}
+	foreignDeliveries, err := hooks.ListDeliveries(ctx, foreignHook.ID, 10, 0)
+	if err != nil || len(foreignDeliveries) != 0 {
+		t.Fatalf("foreign deliveries=%+v err=%v", foreignDeliveries, err)
+	}
+
+	failingResult := callTest(failingHook.ID)
+	if failingResult.Code != http.StatusBadGateway {
+		t.Fatalf("failed delivery status=%d body=%s", failingResult.Code, failingResult.Body.String())
+	}
+	var failureResponse struct {
+		Status     string `json:"status"`
+		EventID    string `json:"event_id"`
+		StatusCode int    `json:"status_code"`
+	}
+	if err := json.Unmarshal(failingResult.Body.Bytes(), &failureResponse); err != nil {
+		t.Fatalf("decode failure response: %v", err)
+	}
+	if failureResponse.Status != "failed" || failureResponse.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("failure response=%+v", failureResponse)
+	}
+	select {
+	case <-failingRequests:
+	case <-time.After(time.Second):
+		t.Fatal("failing owned webhook receiver was not contacted")
+	}
+	failingDeliveries, err := hooks.ListDeliveries(ctx, failingHook.ID, 10, 0)
+	if err != nil || len(failingDeliveries) != 1 {
+		t.Fatalf("failing deliveries=%+v err=%v", failingDeliveries, err)
+	}
+	if failingDeliveries[0].EventID != failureResponse.EventID || failingDeliveries[0].Success || failingDeliveries[0].StatusCode != http.StatusInternalServerError {
+		t.Fatalf("failing delivery=%+v", failingDeliveries[0])
+	}
+
+	redirectResult := callTest(redirectHook.ID)
+	if redirectResult.Code != http.StatusBadGateway {
+		t.Fatalf("redirect delivery status=%d body=%s", redirectResult.Code, redirectResult.Body.String())
+	}
+	select {
+	case <-redirectTargetRequests:
+		t.Fatal("webhook delivery followed a redirect and dropped its POST contract")
+	case <-time.After(100 * time.Millisecond):
+	}
+	redirectDeliveries, err := hooks.ListDeliveries(ctx, redirectHook.ID, 10, 0)
+	if err != nil || len(redirectDeliveries) != 1 || redirectDeliveries[0].Success || redirectDeliveries[0].StatusCode != http.StatusFound {
+		t.Fatalf("redirect deliveries=%+v err=%v", redirectDeliveries, err)
+	}
+
+	for attempt := 2; attempt <= 10; attempt++ {
+		result := callTest(failingHook.ID)
+		if result.Code != http.StatusBadGateway {
+			t.Fatalf("failed delivery attempt %d status=%d body=%s", attempt, result.Code, result.Body.String())
+		}
+		select {
+		case <-failingRequests:
+		case <-time.After(time.Second):
+			t.Fatalf("failing receiver was not contacted for attempt %d", attempt)
+		}
+	}
+	deactivated, err := hooks.GetByID(ctx, failingHook.ID)
+	if err != nil || deactivated.IsActive || deactivated.FailureCount != 10 {
+		t.Fatalf("deactivated webhook=%+v err=%v", deactivated, err)
+	}
+}

--- a/internal/repository/mention.go
+++ b/internal/repository/mention.go
@@ -2,9 +2,11 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -39,6 +41,37 @@ func (r *MentionRepo) Create(ctx context.Context, contentID, contentType, mentio
 		return fmt.Errorf("create mention: %w", err)
 	}
 	return nil
+}
+
+// CreateForPublicComment persists a resolved comment mention only when both
+// the comment and its parent post are public at this statement's commit
+// boundary. Row locks serialize concurrent deletion and quarantine updates.
+// The returned flag is true only when this call inserted the durable mention.
+func (r *MentionRepo) CreateForPublicComment(ctx context.Context, commentID, mentionedID, mentionerID string) (bool, error) {
+	var created bool
+	err := r.pool.QueryRow(ctx, `
+		WITH public_comment AS MATERIALIZED (
+			SELECT c.id
+			FROM comments AS c
+			JOIN posts AS p ON p.id = c.post_id
+			WHERE c.id = $1
+			  AND c.deleted_at IS NULL
+			  AND p.deleted_at IS NULL
+			  AND NOT p.quarantined
+			FOR SHARE OF c, p
+		)
+		INSERT INTO mentions (content_id, content_type, mentioned_id, mentioner_id)
+		SELECT id, 'comment', $2, $3
+		FROM public_comment
+		ON CONFLICT (content_id, content_type, mentioned_id) DO NOTHING
+		RETURNING TRUE`, commentID, mentionedID, mentionerID).Scan(&created)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("create public comment mention: %w", err)
+	}
+	return created, nil
 }
 
 // MentionWithContext is the rendering-ready shape returned by

--- a/internal/repository/mention_test.go
+++ b/internal/repository/mention_test.go
@@ -1,0 +1,68 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/surya-koritala/loomfeed/internal/database"
+	"github.com/surya-koritala/loomfeed/internal/models"
+	"github.com/surya-koritala/loomfeed/internal/repository"
+)
+
+func TestCreateForPublicCommentRechecksConcurrentQuarantine(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool, "mentions", "comments", "posts", "communities", "human_users", "participants")
+	ctx := context.Background()
+
+	participants := repository.NewParticipantRepo(pool)
+	communities := repository.NewCommunityRepo(pool)
+	posts := repository.NewPostRepo(pool)
+	comments := repository.NewCommentRepo(pool)
+	mentions := repository.NewMentionRepo(pool)
+	author := createTestOwner(t, participants, ctx, "mention-author")
+	mentioned := createTestOwner(t, participants, ctx, "mention-recipient")
+	community := createTestCommunity(t, communities, ctx, author.ID, "mention-publicity")
+	post := createTestPost(t, posts, ctx, community.ID, author.ID, "Mention publicity")
+	comment, err := comments.Create(ctx, &models.Comment{
+		PostID: post.ID, AuthorID: author.ID, AuthorType: models.ParticipantHuman, Body: "@mention-recipient",
+	})
+	if err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	quarantineTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin quarantine: %v", err)
+	}
+	defer func() { _ = quarantineTx.Rollback(ctx) }()
+	if _, err := quarantineTx.Exec(ctx, `UPDATE posts SET quarantined = TRUE WHERE id = $1`, post.ID); err != nil {
+		t.Fatalf("stage quarantine: %v", err)
+	}
+
+	type outcome struct {
+		created bool
+		err     error
+	}
+	result := make(chan outcome, 1)
+	go func() {
+		created, err := mentions.CreateForPublicComment(ctx, comment.ID, mentioned.ID, author.ID)
+		result <- outcome{created: created, err: err}
+	}()
+	select {
+	case got := <-result:
+		t.Fatalf("mention persistence did not wait for concurrent quarantine: %+v", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := quarantineTx.Commit(ctx); err != nil {
+		t.Fatalf("commit quarantine: %v", err)
+	}
+	got := <-result
+	if got.err != nil || got.created {
+		t.Fatalf("mention created after concurrent quarantine: %+v", got)
+	}
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM mentions WHERE content_id = $1`, comment.ID).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("persisted mentions=%d err=%v", count, err)
+	}
+}

--- a/internal/repository/post.go
+++ b/internal/repository/post.go
@@ -688,6 +688,69 @@ func (r *PostRepo) SetQuarantined(ctx context.Context, postID string, quarantine
 	return nil
 }
 
+// PublishQuarantined atomically releases a quarantined post and returns the
+// published row. Exactly one concurrent caller can win the transition.
+func (r *PostRepo) PublishQuarantined(ctx context.Context, postID string) (*models.PostWithAuthor, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin publish quarantined post: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var claimed bool
+	err = tx.QueryRow(ctx, `
+		UPDATE posts p
+		SET quarantined = FALSE, updated_at = NOW()
+		WHERE p.id = $1
+		  AND p.quarantined = TRUE
+		  AND (
+		    p.author_type <> 'agent'
+		    OR p.human_verification_count > 0
+		    OR NOT EXISTS (
+		      SELECT 1 FROM quality_gates q
+		      WHERE q.community_id = p.community_id
+		        AND q.require_human_verification = TRUE
+		    )
+		  )
+		RETURNING TRUE`, postID).Scan(&claimed)
+	if errors.Is(err, pgx.ErrNoRows) {
+		var blocked bool
+		if err := tx.QueryRow(ctx, `
+			SELECT EXISTS (
+			  SELECT 1
+			  FROM posts p
+			  JOIN quality_gates q ON q.community_id = p.community_id
+			  WHERE p.id = $1
+			    AND p.quarantined = TRUE
+			    AND p.author_type = 'agent'
+			    AND p.human_verification_count = 0
+			    AND q.require_human_verification = TRUE
+			)`, postID).Scan(&blocked); err != nil {
+			return nil, fmt.Errorf("check human verification gate: %w", err)
+		}
+		if blocked {
+			return nil, ErrHumanVerificationRequired
+		}
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("publish quarantined post: %w", err)
+	}
+	if !claimed {
+		return nil, nil
+	}
+
+	row := tx.QueryRow(ctx, postJoinSelect+` WHERE p.id = $1 AND p.deleted_at IS NULL`, postID)
+	published, err := scanPostWithAuthor(row)
+	if err != nil {
+		return nil, fmt.Errorf("read published post: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit published post: %w", err)
+	}
+	return &published, nil
+}
+
 // CreateWithCrosspost inserts a new post with a crossposted_from reference.
 func (r *PostRepo) CreateWithCrosspost(ctx context.Context, p *models.Post) (*models.Post, error) {
 	if p.PostType == "" {
@@ -1040,12 +1103,32 @@ func (r *PostRepo) SetQuestionStatusIfCurrent(ctx context.Context, postID, curre
 	return err
 }
 
-// AcceptAnswer sets the accepted_answer_id on a post.
-func (r *PostRepo) AcceptAnswer(ctx context.Context, postID, commentID string) error {
-	_, err := r.pool.Exec(ctx,
-		`UPDATE posts SET accepted_answer_id = $1 WHERE id = $2`,
-		commentID, postID)
-	return err
+// AcceptAnswer atomically marks a comment as accepted and the question as
+// answered. It returns the answer author's participant ID and whether the
+// question was public at the mutation's commit boundary for downstream
+// reputation and webhook events. The join prevents accepting a comment from a
+// different post or a deleted comment.
+func (r *PostRepo) AcceptAnswer(ctx context.Context, postID, commentID string) (string, bool, error) {
+	var answerAuthorID string
+	var public bool
+	err := r.pool.QueryRow(ctx, `
+		WITH answer AS MATERIALIZED (
+			SELECT id, author_id
+			FROM comments
+			WHERE id = $2
+			  AND post_id = $1
+			  AND deleted_at IS NULL
+			FOR UPDATE
+		)
+		UPDATE posts AS p
+		SET accepted_answer_id = $2,
+		    question_status = $3
+		FROM answer AS c
+		WHERE p.id = $1
+		  AND p.deleted_at IS NULL
+		RETURNING c.author_id, NOT p.quarantined`,
+		postID, commentID, string(models.QuestionStatusAnswered)).Scan(&answerAuthorID, &public)
+	return answerAuthorID, public, err
 }
 
 // ListBySubscriptions returns paginated posts from communities the participant is subscribed to.

--- a/internal/repository/verification.go
+++ b/internal/repository/verification.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/surya-koritala/loomfeed/internal/models"
 )
 
 // Verifier represents a human who verified a post.
@@ -27,12 +28,21 @@ func NewVerificationRepo(pool *pgxpool.Pool) *VerificationRepo {
 }
 
 // Verify inserts a verification and increments the post's count atomically.
-func (r *VerificationRepo) Verify(ctx context.Context, postID, verifierID string) error {
+// It returns the transaction-consistent post snapshot when this verification
+// published a gate-held agent post, otherwise nil.
+func (r *VerificationRepo) Verify(ctx context.Context, postID, verifierID string) (*models.PostWithAuthor, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return nil, fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Serialize verifications for this post so count materialization and the
+	// quarantined -> public transition stay correct under concurrent verifiers.
+	var wasQuarantined bool
+	if err := tx.QueryRow(ctx, `SELECT quarantined FROM posts WHERE id = $1 FOR UPDATE`, postID).Scan(&wasQuarantined); err != nil {
+		return nil, fmt.Errorf("lock post for verification: %w", err)
+	}
 
 	_, err = tx.Exec(ctx, `
 		INSERT INTO human_verifications (post_id, verifier_id)
@@ -40,10 +50,11 @@ func (r *VerificationRepo) Verify(ctx context.Context, postID, verifierID string
 		ON CONFLICT DO NOTHING`,
 		postID, verifierID)
 	if err != nil {
-		return fmt.Errorf("insert verification: %w", err)
+		return nil, fmt.Errorf("insert verification: %w", err)
 	}
 
-	_, err = tx.Exec(ctx, `
+	var nowQuarantined bool
+	err = tx.QueryRow(ctx, `
 		UPDATE posts
 		SET human_verification_count = (
 			SELECT COUNT(*) FROM human_verifications WHERE post_id = $1
@@ -56,16 +67,25 @@ func (r *VerificationRepo) Verify(ctx context.Context, postID, verifierID string
 			) THEN FALSE
 			ELSE quarantined
 		END
-		WHERE id = $1`,
-		postID)
+		WHERE id = $1
+		RETURNING quarantined`, postID).Scan(&nowQuarantined)
 	if err != nil {
-		return fmt.Errorf("update verification count: %w", err)
+		return nil, fmt.Errorf("update verification count: %w", err)
+	}
+	var published *models.PostWithAuthor
+	if wasQuarantined && !nowQuarantined {
+		row := tx.QueryRow(ctx, postJoinSelect+` WHERE p.id = $1 AND p.deleted_at IS NULL`, postID)
+		post, err := scanPostWithAuthor(row)
+		if err != nil {
+			return nil, fmt.Errorf("read verified published post: %w", err)
+		}
+		published = &post
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("commit tx: %w", err)
+		return nil, fmt.Errorf("commit tx: %w", err)
 	}
-	return nil
+	return published, nil
 }
 
 // Unverify removes a verification and decrements the post's count atomically.
@@ -75,6 +95,12 @@ func (r *VerificationRepo) Unverify(ctx context.Context, postID, verifierID stri
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Match Verify's lock order to avoid post/verification-row deadlocks.
+	var exists bool
+	if err := tx.QueryRow(ctx, `SELECT TRUE FROM posts WHERE id = $1 FOR UPDATE`, postID).Scan(&exists); err != nil {
+		return fmt.Errorf("lock post for unverification: %w", err)
+	}
 
 	_, err = tx.Exec(ctx, `
 		DELETE FROM human_verifications

--- a/internal/repository/verification_test.go
+++ b/internal/repository/verification_test.go
@@ -40,7 +40,7 @@ func TestVerificationRepo_VerifyAndUnverify(t *testing.T) {
 	}
 
 	// Verify
-	if err := verifyRepo.Verify(ctx, post.ID, owner.ID); err != nil {
+	if _, err := verifyRepo.Verify(ctx, post.ID, owner.ID); err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestVerificationRepo_VerifyAndUnverify(t *testing.T) {
 	}
 
 	// Verify again (idempotent -- ON CONFLICT DO NOTHING)
-	if err := verifyRepo.Verify(ctx, post.ID, owner.ID); err != nil {
+	if _, err := verifyRepo.Verify(ctx, post.ID, owner.ID); err != nil {
 		t.Fatalf("Verify again: %v", err)
 	}
 
@@ -123,10 +123,10 @@ func TestVerificationRepo_MultipleVerifiers(t *testing.T) {
 	post := createTestPost(t, postRepo, ctx, community.ID, owner.ID, "Multi Verify Post")
 
 	// Two different verifiers
-	if err := verifyRepo.Verify(ctx, post.ID, owner.ID); err != nil {
+	if _, err := verifyRepo.Verify(ctx, post.ID, owner.ID); err != nil {
 		t.Fatalf("Verify owner: %v", err)
 	}
-	if err := verifyRepo.Verify(ctx, post.ID, verifier2.ID); err != nil {
+	if _, err := verifyRepo.Verify(ctx, post.ID, verifier2.ID); err != nil {
 		t.Fatalf("Verify verifier2: %v", err)
 	}
 

--- a/internal/repository/vote.go
+++ b/internal/repository/vote.go
@@ -125,12 +125,16 @@ func (r *VoteRepo) CastVote(ctx context.Context, v *models.Vote) (int, error) {
 // CastWithReputation performs the vote and reputation update in a single transaction.
 // This merges the previously separate vote + reputation flows (2 transactions, 7+ queries)
 // into a single transaction (5 queries). If authorID is empty or equals the voter, the
-// reputation step is skipped.
+// reputation step is skipped. The returned active flag reports whether the
+// requested vote exists after the transaction (false when the request toggled
+// an identical vote off). The returned target-public flag is captured while
+// the target post is locked by the transaction, preventing a concurrent
+// quarantine transition from racing webhook visibility decisions.
 // Also awards a small trust bump (+0.1) to the voter for community participation (Bug 6 fix).
-func (r *VoteRepo) CastWithReputation(ctx context.Context, v *models.Vote, authorID, eventType string, scoreDelta float64) (int, error) {
+func (r *VoteRepo) CastWithReputation(ctx context.Context, v *models.Vote, authorID, eventType string, scoreDelta float64) (int, bool, bool, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("begin tx: %w", err)
+		return 0, false, false, fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -145,20 +149,22 @@ func (r *VoteRepo) CastWithReputation(ctx context.Context, v *models.Vote, autho
 	).Scan(&existingID, &existingDirection)
 
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return 0, fmt.Errorf("check existing vote: %w", err)
+		return 0, false, false, fmt.Errorf("check existing vote: %w", err)
 	}
 
 	// Step 2: Mutate vote — one of delete / update / insert
+	voteActive := true
 	if err == nil {
 		if existingDirection == v.Direction {
 			_, err = tx.Exec(ctx, `DELETE FROM votes WHERE id = $1`, existingID)
 			if err != nil {
-				return 0, fmt.Errorf("delete vote (toggle off): %w", err)
+				return 0, false, false, fmt.Errorf("delete vote (toggle off): %w", err)
 			}
+			voteActive = false
 		} else {
 			_, err = tx.Exec(ctx, `UPDATE votes SET direction = $1 WHERE id = $2`, v.Direction, existingID)
 			if err != nil {
-				return 0, fmt.Errorf("update vote direction: %w", err)
+				return 0, false, false, fmt.Errorf("update vote direction: %w", err)
 			}
 		}
 	} else {
@@ -168,13 +174,14 @@ func (r *VoteRepo) CastWithReputation(ctx context.Context, v *models.Vote, autho
 			v.TargetID, v.TargetType, v.VoterID, v.VoterType, v.Direction,
 		)
 		if err != nil {
-			return 0, fmt.Errorf("insert vote: %w", err)
+			return 0, false, false, fmt.Errorf("insert vote: %w", err)
 		}
 	}
 
 	// Step 3: Recalculate vote_score. Two literal queries instead of
 	// one fmt.Sprintf'd template — see rationale in CastVote above.
 	var newScore int
+	targetPublic := false
 	if v.TargetType == models.TargetComment {
 		err = tx.QueryRow(ctx, `
 			UPDATE comments
@@ -187,6 +194,16 @@ func (r *VoteRepo) CastWithReputation(ctx context.Context, v *models.Vote, autho
 			RETURNING vote_score`,
 			v.TargetID, v.TargetType,
 		).Scan(&newScore)
+		if err == nil {
+			err = tx.QueryRow(ctx, `
+				SELECT c.deleted_at IS NULL
+				   AND p.deleted_at IS NULL
+				   AND NOT p.quarantined
+				FROM comments AS c
+				JOIN posts AS p ON p.id = c.post_id
+				WHERE c.id = $1
+				FOR SHARE OF p`, v.TargetID).Scan(&targetPublic)
+		}
 	} else {
 		err = tx.QueryRow(ctx, `
 			UPDATE posts
@@ -194,16 +211,16 @@ func (r *VoteRepo) CastWithReputation(ctx context.Context, v *models.Vote, autho
 				(SELECT SUM(CASE WHEN direction = 'up' THEN weight ELSE -weight END)
 				 FROM votes WHERE target_id = $1 AND target_type = $2), 0))::integer
 			WHERE id = $1
-			RETURNING vote_score`,
+			RETURNING vote_score, deleted_at IS NULL AND NOT quarantined`,
 			v.TargetID, v.TargetType,
-		).Scan(&newScore)
+		).Scan(&newScore, &targetPublic)
 	}
 	if err != nil {
-		return 0, fmt.Errorf("recalculate vote_score: %w", err)
+		return 0, false, false, fmt.Errorf("recalculate vote_score: %w", err)
 	}
 	isRemoteReply, err := recomputeRemoteReplyTrustTx(ctx, tx, v.TargetID, v.TargetType)
 	if err != nil {
-		return 0, err
+		return 0, false, false, err
 	}
 
 	// Step 4: Reputation update for the content author. Uses the
@@ -214,15 +231,15 @@ func (r *VoteRepo) CastWithReputation(ctx context.Context, v *models.Vote, autho
 	_ = scoreDelta // legacy arg, kept for signature stability
 	if authorID != "" && authorID != v.VoterID && !isRemoteReply {
 		if _, err := ApplyReputationEventTx(ctx, tx, authorID, eventType); err != nil {
-			return 0, err
+			return 0, false, false, err
 		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return 0, fmt.Errorf("commit tx: %w", err)
+		return 0, false, false, fmt.Errorf("commit tx: %w", err)
 	}
 
-	return newScore, nil
+	return newScore, voteActive, targetPublic, nil
 }
 
 // recomputeRemoteReplyTrustTx feeds the locally observed reception of a

--- a/internal/repository/webhook.go
+++ b/internal/repository/webhook.go
@@ -25,6 +25,7 @@ type Webhook struct {
 // WebhookDelivery represents a single webhook delivery attempt.
 type WebhookDelivery struct {
 	ID           string    `json:"id"`
+	EventID      string    `json:"event_id"`
 	WebhookID    string    `json:"webhook_id"`
 	EventType    string    `json:"event_type"`
 	Payload      any       `json:"payload"`
@@ -119,15 +120,15 @@ func (r *WebhookRepo) Delete(ctx context.Context, webhookID, participantID strin
 }
 
 // RecordDelivery logs a webhook delivery attempt.
-func (r *WebhookRepo) RecordDelivery(ctx context.Context, webhookID, eventType string, payload map[string]any, statusCode int, responseBody string, success bool) error {
+func (r *WebhookRepo) RecordDelivery(ctx context.Context, eventID, webhookID, eventType string, payload map[string]any, statusCode int, responseBody string, success bool) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 	_, err = r.pool.Exec(ctx,
-		`INSERT INTO webhook_deliveries (webhook_id, event_type, payload, status_code, response_body, success)
-         VALUES ($1, $2, $3, $4, $5, $6)`,
-		webhookID, eventType, payloadBytes, statusCode, responseBody, success)
+		`INSERT INTO webhook_deliveries (event_id, webhook_id, event_type, payload, status_code, response_body, success)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		eventID, webhookID, eventType, payloadBytes, statusCode, responseBody, success)
 	if err != nil {
 		return fmt.Errorf("record delivery: %w", err)
 	}
@@ -138,31 +139,35 @@ func (r *WebhookRepo) RecordDelivery(ctx context.Context, webhookID, eventType s
 	return nil
 }
 
-// IncrementFailure increments the failure count for a webhook.
-func (r *WebhookRepo) IncrementFailure(ctx context.Context, webhookID string) error {
-	_, err := r.pool.Exec(ctx,
-		`UPDATE webhooks SET failure_count = failure_count + 1 WHERE id = $1`, webhookID)
-	return err
+// RecordFailure atomically increments the consecutive-failure count and
+// deactivates the webhook at the threshold. Keeping both changes in one row
+// update prevents a concurrent successful delivery from being overwritten by
+// a stale threshold decision.
+func (r *WebhookRepo) RecordFailure(ctx context.Context, webhookID string) (int, bool, error) {
+	var count int
+	var active bool
+	err := r.pool.QueryRow(ctx,
+		`UPDATE webhooks
+		 SET failure_count = failure_count + 1,
+		     is_active = is_active AND failure_count + 1 < 10
+		 WHERE id = $1
+		 RETURNING failure_count, is_active`,
+		webhookID).Scan(&count, &active)
+	return count, active, err
 }
 
-// ResetFailure resets the failure count for a webhook to zero.
+// ResetFailure records a successful in-flight delivery. It clears the failure
+// streak and restores a webhook that a concurrent failure may have disabled.
 func (r *WebhookRepo) ResetFailure(ctx context.Context, webhookID string) error {
 	_, err := r.pool.Exec(ctx,
-		`UPDATE webhooks SET failure_count = 0 WHERE id = $1`, webhookID)
-	return err
-}
-
-// Deactivate sets a webhook as inactive.
-func (r *WebhookRepo) Deactivate(ctx context.Context, webhookID string) error {
-	_, err := r.pool.Exec(ctx,
-		`UPDATE webhooks SET is_active = FALSE WHERE id = $1`, webhookID)
+		`UPDATE webhooks SET failure_count = 0, is_active = TRUE WHERE id = $1`, webhookID)
 	return err
 }
 
 // ListDeliveries returns recent delivery logs for a webhook.
 func (r *WebhookRepo) ListDeliveries(ctx context.Context, webhookID string, limit, offset int) ([]WebhookDelivery, error) {
 	rows, err := r.pool.Query(ctx,
-		`SELECT id, webhook_id, event_type, payload, COALESCE(status_code, 0), COALESCE(response_body, ''), delivered_at, success
+		`SELECT id, event_id, webhook_id, event_type, payload, COALESCE(status_code, 0), COALESCE(response_body, ''), delivered_at, success
          FROM webhook_deliveries
          WHERE webhook_id = $1
          ORDER BY delivered_at DESC
@@ -177,7 +182,7 @@ func (r *WebhookRepo) ListDeliveries(ctx context.Context, webhookID string, limi
 	for rows.Next() {
 		var d WebhookDelivery
 		var payloadBytes []byte
-		if err := rows.Scan(&d.ID, &d.WebhookID, &d.EventType, &payloadBytes, &d.StatusCode, &d.ResponseBody, &d.DeliveredAt, &d.Success); err != nil {
+		if err := rows.Scan(&d.ID, &d.EventID, &d.WebhookID, &d.EventType, &payloadBytes, &d.StatusCode, &d.ResponseBody, &d.DeliveredAt, &d.Success); err != nil {
 			return nil, fmt.Errorf("scan delivery: %w", err)
 		}
 		var payloadMap map[string]any

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -7,9 +7,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/surya-koritala/loomfeed/internal/repository"
 	"github.com/surya-koritala/loomfeed/internal/safehttp"
 )
@@ -20,19 +23,49 @@ type Dispatcher struct {
 	client   *http.Client
 }
 
+// Event is the stable, signed wire envelope delivered to webhook receivers.
+type Event struct {
+	ID        string         `json:"id"`
+	Type      string         `json:"event"`
+	Data      map[string]any `json:"data"`
+	Timestamp string         `json:"timestamp"`
+}
+
+// DeliveryResult describes one synchronous delivery attempt.
+type DeliveryResult struct {
+	EventID    string
+	StatusCode int
+	Success    bool
+}
+
 // NewDispatcher creates a new Dispatcher.
 func NewDispatcher(webhooks *repository.WebhookRepo) *Dispatcher {
-	return &Dispatcher{
-		webhooks: webhooks,
-		// SSRF-hardened: URLs are validated at registration, but DNS can be
-		// rebound and hosts can 302 to internal IPs between then and delivery.
-		// This client re-checks the connected IP at dial time on every hop.
-		client: safehttp.NewClient(safehttp.Options{Timeout: 10 * time.Second, MaxRedirects: 3}),
+	// SSRF-hardened: URLs are validated at registration, but DNS can be
+	// rebound and hosts can 302 to internal IPs between then and delivery.
+	// This client re-checks the connected IP at dial time on every hop.
+	return NewDispatcherWithClient(webhooks,
+		safehttp.NewClient(safehttp.Options{Timeout: 10 * time.Second, MaxRedirects: 3}))
+}
+
+// NewDispatcherWithClient creates a dispatcher with an injected HTTP client.
+// Production uses NewDispatcher; injection keeps receiver-level tests local.
+func NewDispatcherWithClient(webhooks *repository.WebhookRepo, client *http.Client) *Dispatcher {
+	if client == nil {
+		client = safehttp.NewClient(safehttp.Options{Timeout: 10 * time.Second, MaxRedirects: 3})
 	}
+	// Webhook delivery has an exact POST-body contract. A 301/302/303 can make
+	// net/http follow as GET without the signed envelope, so never follow a
+	// redirect and never report the redirect target's 2xx as delivery success.
+	clientCopy := *client
+	clientCopy.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &Dispatcher{webhooks: webhooks, client: &clientCopy}
 }
 
 // Dispatch sends an event to all subscribed webhooks (async, non-blocking).
 func (d *Dispatcher) Dispatch(eventType string, payload map[string]any) {
+	event := newEvent(eventType, payload)
 	go func() {
 		ctx := context.Background()
 		hooks, err := d.webhooks.ListByEvent(ctx, eventType)
@@ -41,54 +74,81 @@ func (d *Dispatcher) Dispatch(eventType string, payload map[string]any) {
 		}
 
 		for _, hook := range hooks {
-			go d.deliver(ctx, hook, eventType, payload)
+			hook := hook
+			go func() { _, _ = d.deliver(ctx, hook, event) }()
 		}
 	}()
 }
 
-func (d *Dispatcher) deliver(ctx context.Context, hook repository.Webhook, eventType string, payload map[string]any) {
-	body, _ := json.Marshal(map[string]any{
-		"event":     eventType,
-		"data":      payload,
-		"timestamp": time.Now().UTC().Format(time.RFC3339),
-	})
+// DeliverTo sends one event directly to the selected hook and waits for the
+// attempt to be recorded. It is used by the owned-hook test endpoint; normal
+// event fan-out remains asynchronous through Dispatch.
+func (d *Dispatcher) DeliverTo(ctx context.Context, hook repository.Webhook, eventType string, payload map[string]any) (DeliveryResult, error) {
+	return d.deliver(ctx, hook, newEvent(eventType, payload))
+}
+
+func newEvent(eventType string, payload map[string]any) Event {
+	return Event{
+		ID:        uuid.NewString(),
+		Type:      eventType,
+		Data:      payload,
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func (d *Dispatcher) deliver(ctx context.Context, hook repository.Webhook, event Event) (DeliveryResult, error) {
+	result := DeliveryResult{EventID: event.ID}
+	body, err := json.Marshal(event)
+	if err != nil {
+		d.recordFailure(ctx, hook.ID)
+		return result, fmt.Errorf("marshal webhook event: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", hook.URL, bytes.NewReader(body))
 	if err != nil {
-		_ = d.webhooks.IncrementFailure(ctx, hook.ID)
-		return
+		_ = d.webhooks.RecordDelivery(ctx, event.ID, hook.ID, event.Type, event.Data, 0, err.Error(), false)
+		d.recordFailure(ctx, hook.ID)
+		return result, fmt.Errorf("create webhook request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Loomfeed-Event", eventType)
+	req.Header.Set("X-Loomfeed-Event", event.Type)
+	req.Header.Set("X-Loomfeed-Event-ID", event.ID)
 
 	// HMAC signature for verification
 	mac := hmac.New(sha256.New, []byte(hook.Secret))
 	mac.Write(body)
 	req.Header.Set("X-Loomfeed-Signature", "sha256="+hex.EncodeToString(mac.Sum(nil)))
 
-	resp, err := d.client.Do(req)
-	success := err == nil && resp != nil && resp.StatusCode >= 200 && resp.StatusCode < 300
+	resp, deliveryErr := d.client.Do(req)
+	result.Success = deliveryErr == nil && resp != nil && resp.StatusCode >= 200 && resp.StatusCode < 300
 
-	var statusCode int
 	var respBody string
 	if resp != nil {
-		statusCode = resp.StatusCode
+		result.StatusCode = resp.StatusCode
 		// Read first 1KB of response
-		buf := make([]byte, 1024)
-		n, _ := resp.Body.Read(buf)
-		respBody = string(buf[:n])
+		responseBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		respBody = string(responseBytes)
 		_ = resp.Body.Close()
+	} else if deliveryErr != nil {
+		respBody = deliveryErr.Error()
 	}
 
-	_ = d.webhooks.RecordDelivery(ctx, hook.ID, eventType, payload, statusCode, respBody, success)
+	recordErr := d.webhooks.RecordDelivery(ctx, event.ID, hook.ID, event.Type, event.Data, result.StatusCode, respBody, result.Success)
 
-	if !success {
-		_ = d.webhooks.IncrementFailure(ctx, hook.ID)
-		// Disable webhook after 10 consecutive failures
-		if hook.FailureCount >= 9 {
-			_ = d.webhooks.Deactivate(ctx, hook.ID)
-		}
+	if !result.Success {
+		d.recordFailure(ctx, hook.ID)
 	} else {
 		_ = d.webhooks.ResetFailure(ctx, hook.ID)
 	}
+	if recordErr != nil {
+		return result, recordErr
+	}
+	if deliveryErr != nil {
+		return result, deliveryErr
+	}
+	return result, nil
+}
+
+func (d *Dispatcher) recordFailure(ctx context.Context, webhookID string) {
+	_, _, _ = d.webhooks.RecordFailure(ctx, webhookID)
 }

--- a/internal/webhook/dispatcher_integration_test.go
+++ b/internal/webhook/dispatcher_integration_test.go
@@ -1,0 +1,257 @@
+package webhook_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/surya-koritala/loomfeed/internal/database"
+	"github.com/surya-koritala/loomfeed/internal/models"
+	"github.com/surya-koritala/loomfeed/internal/repository"
+	"github.com/surya-koritala/loomfeed/internal/webhook"
+)
+
+type receivedWebhook struct {
+	body    []byte
+	headers http.Header
+	event   webhook.Event
+}
+
+func TestDispatcherDeliversEverySupportedEventWithStableIdentity(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool, "webhook_deliveries", "webhooks", "human_users", "participants")
+	ctx := context.Background()
+
+	participants := repository.NewParticipantRepo(pool)
+	owner, err := participants.CreateHuman(ctx, &models.HumanUser{
+		Participant:  models.Participant{DisplayName: "Webhook Contract Owner"},
+		Email:        fmt.Sprintf("webhook-contract-%d@example.com", time.Now().UnixNano()),
+		PasswordHash: "test-hash",
+	})
+	if err != nil {
+		t.Fatalf("create webhook owner: %v", err)
+	}
+
+	events := webhook.SupportedEvents()
+	if len(events) == 0 {
+		t.Fatal("supported webhook event catalog is empty")
+	}
+	received := make(chan receivedWebhook, len(events)*2)
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			t.Errorf("read webhook body: %v", readErr)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var event webhook.Event
+		if err := json.Unmarshal(body, &event); err != nil {
+			t.Errorf("decode webhook body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		received <- receivedWebhook{body: body, headers: r.Header.Clone(), event: event}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer receiver.Close()
+
+	const secret = "webhook-contract-secret"
+	hooks := repository.NewWebhookRepo(pool)
+	hookA, err := hooks.Create(ctx, owner.ID, receiver.URL, secret, events)
+	if err != nil {
+		t.Fatalf("create first webhook: %v", err)
+	}
+	hookB, err := hooks.Create(ctx, owner.ID, receiver.URL, secret, events)
+	if err != nil {
+		t.Fatalf("create second webhook: %v", err)
+	}
+
+	dispatcher := webhook.NewDispatcherWithClient(hooks, receiver.Client())
+	for _, eventType := range events {
+		dispatcher.Dispatch(eventType, map[string]any{"contract_event": eventType})
+	}
+
+	receivedByType := make(map[string][]receivedWebhook, len(events))
+	receivedCount := 0
+	deadline := time.After(5 * time.Second)
+	for receivedCount < len(events)*2 {
+		select {
+		case request := <-received:
+			receivedByType[request.event.Type] = append(receivedByType[request.event.Type], request)
+			receivedCount++
+		case <-deadline:
+			t.Fatalf("received %d/%d supported event deliveries: %v", receivedCount, len(events)*2, receivedByType)
+		}
+	}
+
+	eventIDs := make(map[string]struct{}, len(events))
+	for _, eventType := range events {
+		requests := receivedByType[eventType]
+		if len(requests) != 2 {
+			t.Fatalf("supported event %q deliveries=%d, want two", eventType, len(requests))
+		}
+		if requests[0].event.ID != requests[1].event.ID {
+			t.Errorf("event %q fan-out IDs differ: %q and %q", eventType, requests[0].event.ID, requests[1].event.ID)
+		}
+		if _, err := uuid.Parse(requests[0].event.ID); err != nil {
+			t.Errorf("event %q id %q is not a UUID: %v", eventType, requests[0].event.ID, err)
+		}
+		if _, duplicate := eventIDs[requests[0].event.ID]; duplicate {
+			t.Errorf("event id %q was reused across dispatches", requests[0].event.ID)
+		}
+		eventIDs[requests[0].event.ID] = struct{}{}
+		for _, request := range requests {
+			if request.headers.Get("X-Loomfeed-Event") != eventType {
+				t.Errorf("event header=%q, want %q", request.headers.Get("X-Loomfeed-Event"), eventType)
+			}
+			if request.headers.Get("X-Loomfeed-Event-ID") != request.event.ID {
+				t.Errorf("event id header=%q, want %q", request.headers.Get("X-Loomfeed-Event-ID"), request.event.ID)
+			}
+			if got := request.event.Data["contract_event"]; got != eventType {
+				t.Errorf("event %q payload marker=%v", eventType, got)
+			}
+			if _, err := time.Parse(time.RFC3339Nano, request.event.Timestamp); err != nil {
+				t.Errorf("event %q timestamp %q: %v", eventType, request.event.Timestamp, err)
+			}
+
+			mac := hmac.New(sha256.New, []byte(secret))
+			_, _ = mac.Write(request.body)
+			wantSignature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+			if !hmac.Equal([]byte(request.headers.Get("X-Loomfeed-Signature")), []byte(wantSignature)) {
+				t.Errorf("event %q signature does not match raw body", eventType)
+			}
+		}
+	}
+
+	assertDeliveries := func(hookID string) {
+		t.Helper()
+		var deliveries []repository.WebhookDelivery
+		for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+			deliveries, err = hooks.ListDeliveries(ctx, hookID, len(events)+1, 0)
+			if err != nil {
+				t.Fatalf("list deliveries: %v", err)
+			}
+			if len(deliveries) == len(events) {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if len(deliveries) != len(events) {
+			t.Fatalf("delivery records=%d, want %d", len(deliveries), len(events))
+		}
+		for _, delivery := range deliveries {
+			requests := receivedByType[delivery.EventType]
+			if len(requests) != 2 {
+				t.Errorf("unexpected delivery event type %q", delivery.EventType)
+				continue
+			}
+			if delivery.EventID != requests[0].event.ID {
+				t.Errorf("delivery event id=%q, want %q", delivery.EventID, requests[0].event.ID)
+			}
+			if delivery.WebhookID != hookID || !delivery.Success || delivery.StatusCode != http.StatusAccepted {
+				t.Errorf("delivery record=%+v", delivery)
+			}
+			payload, ok := delivery.Payload.(map[string]any)
+			if !ok || payload["contract_event"] != delivery.EventType {
+				t.Errorf("delivery payload=%#v for %q", delivery.Payload, delivery.EventType)
+			}
+		}
+	}
+	assertDeliveries(hookA.ID)
+	assertDeliveries(hookB.ID)
+}
+
+func TestConcurrentSuccessPreventsStaleFailureDeactivation(t *testing.T) {
+	pool := database.TestPool(t)
+	database.CleanupTables(t, pool, "webhook_deliveries", "webhooks", "human_users", "participants")
+	ctx := context.Background()
+
+	participants := repository.NewParticipantRepo(pool)
+	owner, err := participants.CreateHuman(ctx, &models.HumanUser{
+		Participant: models.Participant{DisplayName: "Concurrent Webhook Owner"},
+		Email:       fmt.Sprintf("webhook-concurrency-%d@example.com", time.Now().UnixNano()), PasswordHash: "test-hash",
+	})
+	if err != nil {
+		t.Fatalf("create webhook owner: %v", err)
+	}
+
+	ready := make(chan struct{}, 2)
+	release := make(chan struct{})
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event webhook.Event
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			t.Errorf("decode concurrent webhook: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		ready <- struct{}{}
+		<-release
+		if event.Data["outcome"] == "failure" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer receiver.Close()
+
+	hooks := repository.NewWebhookRepo(pool)
+	hook, err := hooks.Create(ctx, owner.ID, receiver.URL, "concurrent-secret", []string{webhook.EventPostCreated})
+	if err != nil {
+		t.Fatalf("create webhook: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE webhooks SET failure_count = 9 WHERE id = $1`, hook.ID); err != nil {
+		t.Fatalf("seed failure count: %v", err)
+	}
+
+	dispatcher := webhook.NewDispatcherWithClient(hooks, receiver.Client())
+	results := make(chan webhook.DeliveryResult, 2)
+	errors := make(chan error, 2)
+	for _, outcome := range []string{"failure", "success"} {
+		outcome := outcome
+		go func() {
+			result, err := dispatcher.DeliverTo(ctx, *hook, webhook.EventPostCreated, map[string]any{"outcome": outcome})
+			results <- result
+			errors <- err
+		}()
+	}
+	<-ready
+	<-ready
+	close(release)
+
+	var successes, failures int
+	for i := 0; i < 2; i++ {
+		result := <-results
+		if result.Success {
+			successes++
+		} else {
+			failures++
+		}
+		if err := <-errors; err != nil {
+			t.Fatalf("deliver concurrent outcome: %v", err)
+		}
+	}
+	if successes != 1 || failures != 1 {
+		t.Fatalf("concurrent outcomes success=%d failure=%d", successes, failures)
+	}
+
+	stored, err := hooks.GetByID(ctx, hook.ID)
+	if err != nil {
+		t.Fatalf("load webhook after concurrent outcomes: %v", err)
+	}
+	if !stored.IsActive || (stored.FailureCount != 0 && stored.FailureCount != 1) {
+		t.Fatalf("concurrent success/failure left stale state: %+v", stored)
+	}
+	deliveries, err := hooks.ListDeliveries(ctx, hook.ID, 10, 0)
+	if err != nil || len(deliveries) != 2 {
+		t.Fatalf("concurrent delivery records=%+v err=%v", deliveries, err)
+	}
+}

--- a/internal/webhook/events.go
+++ b/internal/webhook/events.go
@@ -1,0 +1,38 @@
+package webhook
+
+import "github.com/surya-koritala/loomfeed/internal/arenaevents"
+
+const (
+	EventPostCreated    = "post.created"
+	EventCommentCreated = "comment.created"
+	EventMention        = "mention"
+	EventVoteReceived   = "vote.received"
+	EventAnswerAccepted = "answer.accepted"
+	EventWebhookTest    = "webhook.test"
+)
+
+var supportedEvents = []string{
+	EventPostCreated,
+	EventCommentCreated,
+	EventMention,
+	EventVoteReceived,
+	EventAnswerAccepted,
+	arenaevents.ChallengeCreated,
+	arenaevents.RoundOpened,
+	arenaevents.BattleCompleted,
+}
+
+// SupportedEvents returns the complete event catalog accepted at registration.
+func SupportedEvents() []string {
+	return append([]string(nil), supportedEvents...)
+}
+
+// IsSupportedEvent reports whether eventType can be registered.
+func IsSupportedEvent(eventType string) bool {
+	for _, supported := range supportedEvents {
+		if eventType == supported {
+			return true
+		}
+	}
+	return false
+}

--- a/migrations/000100_webhook_event_ids.down.sql
+++ b/migrations/000100_webhook_event_ids.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_webhook_deliveries_event_id;
+
+ALTER TABLE webhook_deliveries
+    DROP COLUMN IF EXISTS event_id;

--- a/migrations/000100_webhook_event_ids.up.sql
+++ b/migrations/000100_webhook_event_ids.up.sql
@@ -1,0 +1,21 @@
+ALTER TABLE webhook_deliveries
+    ADD COLUMN event_id UUID;
+
+-- Historical rows predate event envelopes. Their delivery UUID is a stable,
+-- unique identifier that preserves a useful audit reference during upgrade.
+UPDATE webhook_deliveries
+SET event_id = id
+WHERE event_id IS NULL;
+
+ALTER TABLE webhook_deliveries
+    ALTER COLUMN event_id SET DEFAULT uuid_generate_v4();
+
+ALTER TABLE webhook_deliveries
+    ALTER COLUMN event_id SET NOT NULL;
+
+-- Keep the default during rolling upgrades. Older API replicas omit event_id;
+-- they receive a per-delivery UUID until replaced, while current replicas
+-- supply the logical event UUID shared by fan-out deliveries.
+
+CREATE INDEX idx_webhook_deliveries_event_id
+    ON webhook_deliveries(event_id);


### PR DESCRIPTION
Closes #49

## Summary

- deliver webhook.test synchronously only to the selected owned webhook, with write-scope enforcement and exact success/failure reporting
- centralize the registrable event catalog and add stable UUID event envelopes, signed headers, shared fan-out IDs, and delivery-history IDs
- emit every advertised content and Arena event only after the source mutation commits and the content is publicly visible
- serialize quarantine, verification, deletion, vote, answer, mention, and consecutive-failure boundaries to prevent stale or duplicate events
- reject delivery redirects, preserve rolling-upgrade compatibility, and document the exact public webhook contract

## Verification

- clean database-backed suites: go test ./internal/activitypub ./internal/api/handlers ./internal/api/routes ./internal/repository ./internal/webhook -count=1 -p 1
- focused race suites covering real HTTP receivers, signatures, ownership, privacy, deletion, quarantine, and concurrency
- go vet on every changed Go package
- migration 100 rollback to version 99 and upgrade back to 100; verified UUID default, NOT NULL, and historical event_id = id backfill
- two independent reviews completed with zero actionable findings

## Scope

Durable retry scheduling and worker bounds remain in #54.