### PR TITLE
Make SSE delivery race-free and cross-replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See [docs/FEATURE_STATUS.md](docs/FEATURE_STATUS.md) for the complete built-vs-p
 |-------|-----------|
 | Backend | Go 1.25 |
 | Database | PostgreSQL 16 + pgvector + pg_trgm |
-| Cache / Events | Redis (caching, rate limiting, SSE event bus) — optional, degrades gracefully |
+| Cache / Events | Redis (caching, rate limiting, cross-replica SSE Pub/Sub) — optional; SSE falls back to process-local delivery |
 | Frontend | Next.js 15 (App Router) + React 19 + TypeScript + Tailwind CSS 4 |
 | Auth | JWT (access + refresh) + bcrypt API keys + optional GitHub/Google OAuth |
 | Protocols | REST API (90+ endpoints) + MCP (Streamable HTTP + SSE) + A2A |

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -78,9 +78,11 @@ func main() {
 		// Test connection
 		if err := redisClient.Ping(ctx).Err(); err != nil {
 			slog.Warn("redis ping failed, disabling", "error", err)
+			_ = redisClient.Close()
 			redisClient = nil
 		} else {
 			slog.Info("redis connected")
+			defer redisClient.Close()
 		}
 	}
 
@@ -116,6 +118,16 @@ func main() {
 	mux.Handle("GET /metrics", metrics.GuardedHandler(os.Getenv("METRICS_TOKEN")))
 
 	hub := events.NewHub()
+	if redisClient != nil {
+		sharedHub, err := events.NewRedisHub(ctx, redisClient)
+		if err != nil {
+			slog.Warn("Redis SSE event bus unavailable; using process-local delivery", "error", err)
+		} else {
+			hub = sharedHub
+			slog.Info("Redis SSE event bus connected")
+		}
+	}
+	defer hub.Close()
 	routes.Register(mux, pool, cfg, redisCache, hub)
 
 	// metrics.Middleware is innermost (closest to the mux) so the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,7 +60,7 @@ Post authors can attach one subject-agnostic forecast to a post with a predicted
 | Language | Go 1.25 |
 | Database | PostgreSQL 16 + pgvector |
 | Graph | Apache AGE (in PostgreSQL) |
-| Cache | Redis Standard |
+| Cache / Events | Redis Standard (cache, rate limits, SSE Pub/Sub) |
 | Search | pgvector cosine + BM25 via RRF |
 | Frontend | Next.js 15, React 19, TypeScript, Tailwind |
 | Deployment | Docker, Azure Container Apps |
@@ -109,3 +109,4 @@ Post authors can attach one subject-agnostic forecast to a post with a predicted
 7. **Federation stays in-process** — The Core API already owns actor keys, inbox verification, persistence, and post fan-out. The empty standalone service was removed; a separate worker should return only if a durable delivery queue justifies that deployment boundary.
 8. **Predictions lock at their first deadline** — Forecast text and confidence remain revisable only before the original resolve-by time. Resolution is allowed only after that time and is immutable, so an accuracy record cannot be rewritten after the outcome is known.
 9. **Prediction skill is calibrated by forecast family** — Generic binary forecasts contribute `1 - Brier`; three-way sports forecasts contribute `1 - Brier/2` because their Brier range is 0–2. Missing prediction history redistributes the scorecard weight instead of counting as failure.
+10. **SSE is at-most-once** — API replicas use Redis Pub/Sub for cross-replica fan-out and keep immediate process-local delivery. There is no replay log or global ordering guarantee across publishers. Slow local subscribers drop new events after a 16-event buffer; the per-replica Redis publish queue is bounded at 256. Redis failure degrades to process-local delivery, so clients reconnect and re-read canonical REST state after a gap.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -132,7 +132,7 @@ ones that matter most:
 |----------|----------|---------|-------------|
 | `JWT_SECRET` | **Yes** | — | JWT signing key. The API refuses to boot without it. Generate with `openssl rand -base64 48`. |
 | `DATABASE_URL` | No | localhost dev DSN | PostgreSQL connection string. Set explicitly in production. |
-| `REDIS_URL` | No | `redis://localhost:6379` | Caching, rate limiting, SSE events. Unreachable Redis logs a warning and continues. |
+| `REDIS_URL` | No | `redis://localhost:6379` | Caching, rate limiting, and cross-replica SSE Pub/Sub. Unreachable Redis logs a warning and continues with process-local SSE. |
 | `API_PORT` | No | `8080` | Core API port. |
 | `GATEWAY_PORT` | No | `8081` | MCP gateway port. |
 | `CORE_API_URL` | No | `http://localhost:$API_PORT` | How the gateway reaches the Core API. Set when they run in separate containers. |
@@ -168,6 +168,27 @@ Notes:
   proxy routing are ready. Federation runs in the Core API; there is no
   separate worker. Remote discovery and delivery reject private, loopback,
   link-local, and cloud-metadata targets.
+
+## Real-time SSE delivery
+
+The API sends participant notifications and live post comments over
+Server-Sent Events. Streams clear the normal HTTP write deadline and send a
+heartbeat comment every 15 seconds so long-lived connections remain active
+through idle proxies.
+
+With a healthy `REDIS_URL`, each API replica publishes events through Redis
+Pub/Sub and every replica forwards matching events to its local SSE clients.
+Without Redis, the API stays available but delivery is process-local: an event
+created on one replica cannot reach a stream attached to another replica.
+
+SSE delivery is intentionally at-most-once and has no replay log. Each local
+subscriber has a 16-event buffer; if that client is slower than producers, the
+new event is dropped. Each replica also has a bounded 256-event Redis publish
+queue; when it is full or Redis is unavailable, local delivery is still
+attempted but cross-replica fan-out can be lost. Redis Pub/Sub does not provide
+a global event ordering guarantee across publishers. Clients should reconnect
+and refresh canonical state through the REST endpoints after any disconnect or
+sequence gap.
 
 ## Production Deployment
 

--- a/internal/api/handlers/events.go
+++ b/internal/api/handlers/events.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/surya-koritala/loomfeed/internal/api"
 	"github.com/surya-koritala/loomfeed/internal/api/middleware"
@@ -14,13 +15,14 @@ import (
 
 // EventHandler handles SSE streaming endpoints.
 type EventHandler struct {
-	hub *events.Hub
-	cfg *config.Config
+	hub               *events.Hub
+	cfg               *config.Config
+	heartbeatInterval time.Duration
 }
 
 // NewEventHandler creates a new EventHandler.
 func NewEventHandler(hub *events.Hub, cfg *config.Config) *EventHandler {
-	return &EventHandler{hub: hub, cfg: cfg}
+	return &EventHandler{hub: hub, cfg: cfg, heartbeatInterval: 15 * time.Second}
 }
 
 // Stream handles GET /api/v1/events/stream
@@ -69,38 +71,8 @@ func (h *EventHandler) Stream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use ResponseController for flushing (works through wrapped ResponseWriters)
-	rc := http.NewResponseController(w)
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")
-
-	// Send a connected event immediately
-	_, _ = fmt.Fprintf(w, "event: connected\ndata: {\"participant_id\":\"%s\"}\n\n", claims.ParticipantID)
-	_ = rc.Flush()
-
-	ch := h.hub.Subscribe(claims.ParticipantID)
-	defer h.hub.Unsubscribe(claims.ParticipantID, ch)
-
-	notify := r.Context().Done()
-
-	for {
-		select {
-		case event, ok := <-ch:
-			if !ok {
-				return
-			}
-			_, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.Type, event.Data)
-			if err != nil {
-				return
-			}
-			_ = rc.Flush()
-		case <-notify:
-			return
-		}
-	}
+	h.serveStream(w, r, claims.ParticipantID,
+		fmt.Sprintf(`{"participant_id":%q}`, claims.ParticipantID))
 }
 
 // StreamHealth is a simple endpoint to check if SSE is working without auth.
@@ -120,19 +92,31 @@ func (h *EventHandler) PostStream(w http.ResponseWriter, r *http.Request) {
 	}
 	key := "post:" + postID
 
+	h.serveStream(w, r, key, fmt.Sprintf(`{"post_id":%q}`, postID))
+}
+
+func (h *EventHandler) serveStream(w http.ResponseWriter, r *http.Request, key, connectedData string) {
+	// SSE is intentionally long-lived. Clear the per-request deadline inherited
+	// from http.Server.WriteTimeout while keeping the timeout for normal APIs.
 	rc := http.NewResponseController(w)
+	_ = rc.SetWriteDeadline(time.Time{})
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
-	_, _ = fmt.Fprintf(w, "event: connected\ndata: {\"post_id\":\"%s\"}\n\n", postID)
-	_ = rc.Flush()
+	if _, err := fmt.Fprintf(w, "event: connected\ndata: %s\n\n", connectedData); err != nil {
+		return
+	}
+	if err := rc.Flush(); err != nil {
+		return
+	}
 
 	ch := h.hub.Subscribe(key)
 	defer h.hub.Unsubscribe(key, ch)
+	heartbeat := time.NewTicker(h.heartbeatInterval)
+	defer heartbeat.Stop()
 
-	notify := r.Context().Done()
 	for {
 		select {
 		case event, ok := <-ch:
@@ -143,9 +127,18 @@ func (h *EventHandler) PostStream(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return
 			}
-			_ = rc.Flush()
-		case <-notify:
+			if err := rc.Flush(); err != nil {
+				return
+			}
+		case <-r.Context().Done():
 			return
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
+				return
+			}
+			if err := rc.Flush(); err != nil {
+				return
+			}
 		}
 	}
 }

--- a/internal/api/handlers/events_test.go
+++ b/internal/api/handlers/events_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/surya-koritala/loomfeed/internal/api/middleware"
+	"github.com/surya-koritala/loomfeed/internal/auth"
+	"github.com/surya-koritala/loomfeed/internal/config"
+	"github.com/surya-koritala/loomfeed/internal/events"
+)
+
+func TestSSEStreamsSurviveServerWriteTimeout(t *testing.T) {
+	for _, test := range sseHandlerTests() {
+		t.Run(test.name, func(t *testing.T) {
+			hub := events.NewHub()
+			handler := NewEventHandler(hub, &config.Config{})
+			mux := http.NewServeMux()
+			test.register(mux, handler)
+
+			server := httptest.NewUnstartedServer(mux)
+			server.Config.WriteTimeout = 50 * time.Millisecond
+			server.Start()
+			defer server.Close()
+
+			response, err := server.Client().Get(server.URL + test.path)
+			if err != nil {
+				t.Fatalf("open SSE stream: %v", err)
+			}
+			defer response.Body.Close()
+			reader := bufio.NewReader(response.Body)
+			if frame := readSSEFrame(t, reader); !strings.Contains(frame, "event: connected") {
+				t.Fatalf("initial frame=%q", frame)
+			}
+
+			// The next write happens after the HTTP server deadline. SSE handlers
+			// must clear it so the long-lived response still works.
+			time.Sleep(150 * time.Millisecond)
+			hub.Publish(test.key, events.Event{Type: "comment.created", Data: `{"comment_id":"comment-1"}`})
+
+			frame := readSSEFrame(t, reader)
+			if !strings.Contains(frame, "event: comment.created") || !strings.Contains(frame, `"comment_id":"comment-1"`) {
+				t.Fatalf("event frame=%q", frame)
+			}
+		})
+	}
+}
+
+func TestSSEStreamsSendHeartbeatComments(t *testing.T) {
+	for _, test := range sseHandlerTests() {
+		t.Run(test.name, func(t *testing.T) {
+			hub := events.NewHub()
+			handler := NewEventHandler(hub, &config.Config{})
+			handler.heartbeatInterval = 10 * time.Millisecond
+			mux := http.NewServeMux()
+			test.register(mux, handler)
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			response, err := server.Client().Get(server.URL + test.path)
+			if err != nil {
+				t.Fatalf("open SSE stream: %v", err)
+			}
+			defer response.Body.Close()
+			reader := bufio.NewReader(response.Body)
+			_ = readSSEFrame(t, reader)
+
+			if frame := readSSEFrame(t, reader); frame != ": heartbeat\n\n" {
+				t.Fatalf("heartbeat frame=%q", frame)
+			}
+		})
+	}
+}
+
+type sseHandlerTest struct {
+	name     string
+	path     string
+	key      string
+	register func(*http.ServeMux, *EventHandler)
+}
+
+func sseHandlerTests() []sseHandlerTest {
+	return []sseHandlerTest{
+		{
+			name: "participant stream",
+			path: "/api/v1/events/stream",
+			key:  "participant-1",
+			register: func(mux *http.ServeMux, handler *EventHandler) {
+				mux.HandleFunc("GET /api/v1/events/stream", func(w http.ResponseWriter, r *http.Request) {
+					claims := &auth.Claims{ParticipantID: "participant-1"}
+					r = r.WithContext(context.WithValue(r.Context(), middleware.ClaimsKey, claims))
+					handler.Stream(w, r)
+				})
+			},
+		},
+		{
+			name: "post stream",
+			path: "/api/v1/events/post/post-1",
+			key:  "post:post-1",
+			register: func(mux *http.ServeMux, handler *EventHandler) {
+				mux.HandleFunc("GET /api/v1/events/post/{id}", handler.PostStream)
+			},
+		},
+	}
+}
+
+func readSSEFrame(t *testing.T, reader *bufio.Reader) string {
+	t.Helper()
+	type result struct {
+		frame string
+		err   error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		var frame strings.Builder
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				resultCh <- result{err: err}
+				return
+			}
+			frame.WriteString(line)
+			if line == "\n" {
+				resultCh <- result{frame: frame.String()}
+				return
+			}
+		}
+	}()
+	select {
+	case got := <-resultCh:
+		if got.err != nil {
+			if got.err == io.EOF {
+				t.Fatalf("SSE stream closed before the next frame")
+			}
+			t.Fatalf("read SSE frame: %v", got.err)
+		}
+		return got.frame
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for SSE frame")
+		return ""
+	}
+}

--- a/internal/api/middleware/compress.go
+++ b/internal/api/middleware/compress.go
@@ -53,9 +53,9 @@ func Gzip(next http.Handler) http.Handler {
 		}
 
 		// Skip for SSE endpoints — compression buffers events and
-		// breaks streaming even with Flush forwarding. Both the
-		// internal events stream and the public MCP SSE transport.
-		if strings.Contains(r.URL.Path, "/events/stream") ||
+		// breaks streaming even with Flush forwarding. This covers all
+		// Loomfeed event streams and the public MCP SSE transport.
+		if strings.HasPrefix(r.URL.Path, "/api/v1/events/") ||
 			strings.HasPrefix(r.URL.Path, "/mcp/") {
 			next.ServeHTTP(w, r)
 			return

--- a/internal/api/middleware/compress_test.go
+++ b/internal/api/middleware/compress_test.go
@@ -64,6 +64,33 @@ func TestGzip_SkipsWhenNotAccepted(t *testing.T) {
 	}
 }
 
+func TestGzip_SkipsAllSSEEventRoutes(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: connected\n\n"))
+	})
+
+	for _, path := range []string{
+		"/api/v1/events/stream",
+		"/api/v1/events/post/post-1",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Accept-Encoding", "gzip")
+			rec := httptest.NewRecorder()
+
+			middleware.Gzip(inner).ServeHTTP(rec, req)
+
+			if got := rec.Header().Get("Content-Encoding"); got != "" {
+				t.Fatalf("SSE response Content-Encoding=%q, want no compression", got)
+			}
+			if got := rec.Body.String(); got != "event: connected\n\n" {
+				t.Fatalf("SSE response body=%q", got)
+			}
+		})
+	}
+}
+
 func TestGzip_SkipsSmallResponses(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("hi"))

--- a/internal/events/hub.go
+++ b/internal/events/hub.go
@@ -1,17 +1,51 @@
 package events
 
-import "sync"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	redisEventChannel   = "loomfeed:sse:events:v1"
+	brokerQueueCapacity = 256
+	brokerPublishLimit  = time.Second
+)
 
 // Event represents a server-sent event.
 type Event struct {
-	Type string
-	Data string
+	Type string `json:"type"`
+	Data string `json:"data"`
+}
+
+type brokerEvent struct {
+	Origin    string `json:"origin"`
+	Key       string `json:"key,omitempty"`
+	Broadcast bool   `json:"broadcast,omitempty"`
+	Event     Event  `json:"event"`
 }
 
 // Hub manages SSE subscriptions and event publishing.
 type Hub struct {
 	mu          sync.RWMutex
 	subscribers map[string][]chan Event
+	closed      bool
+
+	origin      string
+	redis       redis.UniversalClient
+	pubsub      *redis.PubSub
+	brokerQueue chan brokerEvent
+	brokerCtx   context.Context
+	brokerStop  context.CancelFunc
+	brokerWG    sync.WaitGroup
+	closeOnce   sync.Once
+	closeErr    error
 }
 
 // NewHub creates a new Hub.
@@ -21,39 +55,92 @@ func NewHub() *Hub {
 	}
 }
 
+// NewRedisHub creates a Hub whose events fan out through Redis Pub/Sub while
+// preserving immediate delivery to subscribers in the publishing process.
+func NewRedisHub(ctx context.Context, client redis.UniversalClient) (*Hub, error) {
+	if client == nil {
+		return nil, fmt.Errorf("redis event hub requires a client")
+	}
+	brokerCtx, stop := context.WithCancel(ctx)
+	pubsub := client.Subscribe(brokerCtx, redisEventChannel)
+	if _, err := pubsub.Receive(brokerCtx); err != nil {
+		stop()
+		_ = pubsub.Close()
+		return nil, fmt.Errorf("subscribe Redis event hub: %w", err)
+	}
+
+	h := &Hub{
+		subscribers: make(map[string][]chan Event),
+		origin:      uuid.NewString(),
+		redis:       client,
+		pubsub:      pubsub,
+		brokerQueue: make(chan brokerEvent, brokerQueueCapacity),
+		brokerCtx:   brokerCtx,
+		brokerStop:  stop,
+	}
+	messages := pubsub.Channel(redis.WithChannelSize(brokerQueueCapacity))
+	h.brokerWG.Add(2)
+	go h.publishBrokerEvents()
+	go h.receiveBrokerEvents(messages)
+	return h, nil
+}
+
 // Subscribe creates a new channel for the given participant and registers it.
-func (h *Hub) Subscribe(participantID string) chan Event {
+// The receive-only return keeps channel send/close ownership inside the Hub.
+func (h *Hub) Subscribe(participantID string) <-chan Event {
 	ch := make(chan Event, 16)
 	h.mu.Lock()
+	if h.closed {
+		close(ch)
+		h.mu.Unlock()
+		return ch
+	}
 	h.subscribers[participantID] = append(h.subscribers[participantID], ch)
 	h.mu.Unlock()
 	return ch
 }
 
 // Unsubscribe removes a channel from the given participant's subscriptions.
-func (h *Hub) Unsubscribe(participantID string, ch chan Event) {
+func (h *Hub) Unsubscribe(participantID string, ch <-chan Event) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	channels := h.subscribers[participantID]
-	updated := channels[:0]
-	for _, c := range channels {
-		if c != ch {
-			updated = append(updated, c)
+	var removed chan Event
+	for index, c := range channels {
+		if c == ch {
+			removed = c
+			copy(channels[index:], channels[index+1:])
+			channels[len(channels)-1] = nil
+			channels = channels[:len(channels)-1]
+			break
 		}
 	}
-	if len(updated) == 0 {
+	if len(channels) == 0 {
 		delete(h.subscribers, participantID)
 	} else {
-		h.subscribers[participantID] = updated
+		h.subscribers[participantID] = channels
 	}
-	close(ch)
+	if removed != nil {
+		close(removed)
+	}
 }
 
 // Publish sends an event to all channels of the given participant.
 func (h *Hub) Publish(participantID string, event Event) {
+	h.publishLocal(participantID, event)
+	h.enqueueBroker(brokerEvent{Origin: h.origin, Key: participantID, Event: event})
+}
+
+// PublishLocal sends an event only to subscribers in this process. It is for
+// internal worker signals that must not run once per API replica.
+func (h *Hub) PublishLocal(participantID string, event Event) {
+	h.publishLocal(participantID, event)
+}
+
+func (h *Hub) publishLocal(participantID string, event Event) {
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	channels := h.subscribers[participantID]
-	h.mu.RUnlock()
 	for _, ch := range channels {
 		select {
 		case ch <- event:
@@ -65,16 +152,106 @@ func (h *Hub) Publish(participantID string, event Event) {
 
 // Broadcast sends an event to all connected participants.
 func (h *Hub) Broadcast(event Event) {
+	h.broadcastLocal(event)
+	h.enqueueBroker(brokerEvent{Origin: h.origin, Broadcast: true, Event: event})
+}
+
+func (h *Hub) broadcastLocal(event Event) {
 	h.mu.RLock()
-	allChannels := make([]chan Event, 0)
+	defer h.mu.RUnlock()
 	for _, channels := range h.subscribers {
-		allChannels = append(allChannels, channels...)
-	}
-	h.mu.RUnlock()
-	for _, ch := range allChannels {
-		select {
-		case ch <- event:
-		default:
+		for _, ch := range channels {
+			select {
+			case ch <- event:
+			default:
+			}
 		}
 	}
+}
+
+func (h *Hub) enqueueBroker(event brokerEvent) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if h.closed || h.brokerQueue == nil {
+		return
+	}
+	select {
+	case h.brokerQueue <- event:
+	default:
+		slog.Debug("dropping cross-replica SSE event because broker queue is full", "event", event.Event.Type)
+	}
+}
+
+func (h *Hub) publishBrokerEvents() {
+	defer h.brokerWG.Done()
+	for {
+		select {
+		case event := <-h.brokerQueue:
+			payload, err := json.Marshal(event)
+			if err != nil {
+				slog.Warn("encode cross-replica SSE event", "error", err)
+				continue
+			}
+			ctx, cancel := context.WithTimeout(h.brokerCtx, brokerPublishLimit)
+			err = h.redis.Publish(ctx, redisEventChannel, payload).Err()
+			cancel()
+			if err != nil && h.brokerCtx.Err() == nil {
+				slog.Warn("publish cross-replica SSE event", "error", err)
+			}
+		case <-h.brokerCtx.Done():
+			return
+		}
+	}
+}
+
+func (h *Hub) receiveBrokerEvents(messages <-chan *redis.Message) {
+	defer h.brokerWG.Done()
+	for {
+		select {
+		case message, ok := <-messages:
+			if !ok {
+				return
+			}
+			var event brokerEvent
+			if err := json.Unmarshal([]byte(message.Payload), &event); err != nil {
+				slog.Warn("decode cross-replica SSE event", "error", err)
+				continue
+			}
+			if event.Origin == h.origin {
+				continue
+			}
+			if event.Broadcast {
+				h.broadcastLocal(event.Event)
+			} else {
+				h.publishLocal(event.Key, event.Event)
+			}
+		case <-h.brokerCtx.Done():
+			return
+		}
+	}
+}
+
+// Close stops broker fan-out and closes every subscriber channel. Hub is the
+// sole channel closer, serialized against sends by the same mutex.
+func (h *Hub) Close() error {
+	h.closeOnce.Do(func() {
+		h.mu.Lock()
+		h.closed = true
+		for participantID, channels := range h.subscribers {
+			for _, ch := range channels {
+				close(ch)
+			}
+			delete(h.subscribers, participantID)
+		}
+		h.mu.Unlock()
+
+		if h.brokerStop != nil {
+			h.brokerStop()
+		}
+		if h.pubsub != nil {
+			h.closeErr = h.pubsub.Close()
+		}
+		h.brokerWG.Wait()
+	})
+	return h.closeErr
 }

--- a/internal/events/hub_test.go
+++ b/internal/events/hub_test.go
@@ -1,0 +1,206 @@
+package events_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/surya-koritala/loomfeed/internal/events"
+)
+
+func TestHubConcurrentPublishAndUnsubscribe(t *testing.T) {
+	const rounds = 2_000
+	hub := events.NewHub()
+
+	for round := 0; round < rounds; round++ {
+		ch := hub.Subscribe("participant")
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(3)
+		for publisher := 0; publisher < 2; publisher++ {
+			publisher := publisher
+			go func() {
+				defer wg.Done()
+				<-start
+				for attempt := 0; attempt < 8; attempt++ {
+					if publisher == 0 {
+						hub.Publish("participant", events.Event{Type: "test", Data: "{}"})
+					} else {
+						hub.Broadcast(events.Event{Type: "broadcast", Data: "{}"})
+					}
+				}
+			}()
+		}
+		go func() {
+			defer wg.Done()
+			<-start
+			hub.Unsubscribe("participant", ch)
+		}()
+		close(start)
+		wg.Wait()
+	}
+}
+
+func TestHubSlowSubscriberDropsNewestEvent(t *testing.T) {
+	hub := events.NewHub()
+	ch := hub.Subscribe("participant")
+	defer hub.Unsubscribe("participant", ch)
+
+	for sequence := 0; sequence < 17; sequence++ {
+		hub.Publish("participant", events.Event{Type: "sequence", Data: string(rune('a' + sequence))})
+	}
+	for sequence := 0; sequence < 16; sequence++ {
+		want := events.Event{Type: "sequence", Data: string(rune('a' + sequence))}
+		assertEvent(t, ch, want)
+	}
+	select {
+	case event := <-ch:
+		t.Fatalf("slow subscriber received event beyond its buffer: %+v", event)
+	default:
+	}
+}
+
+func TestHubCloseOwnsSubscriberChannelClosure(t *testing.T) {
+	hub := events.NewHub()
+	ch := hub.Subscribe("participant")
+	if err := hub.Close(); err != nil {
+		t.Fatalf("close hub: %v", err)
+	}
+	if _, ok := <-ch; ok {
+		t.Fatal("subscriber channel remained open after hub close")
+	}
+	// A handler cleanup racing or following Hub.Close is idempotent.
+	hub.Unsubscribe("participant", ch)
+}
+
+func TestHubConcurrentPublishUnsubscribeAndClose(t *testing.T) {
+	const rounds = 500
+	for round := 0; round < rounds; round++ {
+		hub := events.NewHub()
+		ch := hub.Subscribe("participant")
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			<-start
+			for attempt := 0; attempt < 8; attempt++ {
+				hub.Publish("participant", events.Event{Type: "test", Data: "{}"})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			hub.Unsubscribe("participant", ch)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := hub.Close(); err != nil {
+				t.Errorf("close hub: %v", err)
+			}
+		}()
+		close(start)
+		wg.Wait()
+	}
+}
+
+func TestRedisHubPublishesOnceLocallyAndAcrossInstances(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	clientA := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	clientB := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() {
+		_ = clientA.Close()
+		_ = clientB.Close()
+	})
+
+	hubA, err := events.NewRedisHub(context.Background(), clientA)
+	if err != nil {
+		t.Fatalf("create first Redis hub: %v", err)
+	}
+	defer hubA.Close()
+	hubB, err := events.NewRedisHub(context.Background(), clientB)
+	if err != nil {
+		t.Fatalf("create second Redis hub: %v", err)
+	}
+	defer hubB.Close()
+
+	local := hubA.Subscribe("participant")
+	defer hubA.Unsubscribe("participant", local)
+	remote := hubB.Subscribe("participant")
+	defer hubB.Unsubscribe("participant", remote)
+	want := events.Event{Type: "mention", Data: `{"comment_id":"comment-1"}`}
+	hubA.Publish("participant", want)
+
+	assertEvent(t, local, want)
+	assertEvent(t, remote, want)
+	select {
+	case duplicate := <-local:
+		t.Fatalf("origin hub received duplicate broker event: %+v", duplicate)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestRedisHubPublishLocalStaysOnOriginInstance(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	clientA := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	clientB := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	defer clientA.Close()
+	defer clientB.Close()
+	hubA, err := events.NewRedisHub(context.Background(), clientA)
+	if err != nil {
+		t.Fatalf("create first Redis hub: %v", err)
+	}
+	defer hubA.Close()
+	hubB, err := events.NewRedisHub(context.Background(), clientB)
+	if err != nil {
+		t.Fatalf("create second Redis hub: %v", err)
+	}
+	defer hubB.Close()
+
+	local := hubA.Subscribe("__worker__")
+	defer hubA.Unsubscribe("__worker__", local)
+	remote := hubB.Subscribe("__worker__")
+	defer hubB.Unsubscribe("__worker__", remote)
+	want := events.Event{Type: "work", Data: `{"id":"job-1"}`}
+	hubA.PublishLocal("__worker__", want)
+	assertEvent(t, local, want)
+	select {
+	case event := <-remote:
+		t.Fatalf("process-local event crossed replicas: %+v", event)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestRedisHubStillDeliversLocallyWhenBrokerIsUnavailable(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	defer client.Close()
+	hub, err := events.NewRedisHub(context.Background(), client)
+	if err != nil {
+		t.Fatalf("create Redis hub: %v", err)
+	}
+	defer hub.Close()
+
+	local := hub.Subscribe("participant")
+	defer hub.Unsubscribe("participant", local)
+	redisServer.Close()
+	want := events.Event{Type: "mention", Data: `{"comment_id":"comment-1"}`}
+	hub.Publish("participant", want)
+	assertEvent(t, local, want)
+}
+
+func assertEvent(t *testing.T, ch <-chan events.Event, want events.Event) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		if got != want {
+			t.Fatalf("event=%+v, want %+v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for event %+v", want)
+	}
+}

--- a/internal/scorecard/worker.go
+++ b/internal/scorecard/worker.go
@@ -95,7 +95,7 @@ func (w *Worker) handleEvent(ctx context.Context, event events.Event) {
 // TriggerCompute publishes a scorecard trigger event. Call from handlers after votes, etc.
 func TriggerCompute(hub *events.Hub, participantID string) {
 	data, _ := json.Marshal(scorecardEvent{ParticipantID: participantID})
-	hub.Publish("__scorecard_worker__", events.Event{
+	hub.PublishLocal("__scorecard_worker__", events.Event{
 		Type: "scorecard.trigger",
 		Data: string(data),
 	})


### PR DESCRIPTION
## Summary

- make the event hub the single owner of subscriber sends and closes, with race-tested unsubscribe/shutdown behavior
- keep SSE streams alive beyond the API write timeout and send heartbeat comments on both participant and post streams
- fan out public SSE events across API replicas through Redis Pub/Sub while preserving process-local fallback
- keep scorecard worker signals local so scaling API replicas does not duplicate internal work
- document the at-most-once, ordering, buffering, and degradation contract

## Verification

- `go vet ./...`
- `go test -race ./... -count=1 -p 1`
- repeated focused race tests for the event hub, both HTTP SSE routes, middleware, scorecard, and sports consumers
- two-hub Redis integration test with local and remote delivery
- real HTTP stream tests beyond `http.Server.WriteTimeout` plus heartbeat tests
- `go build ./cmd/...`
- license, Docker-context, Compose-health, and production-Compose checks

Closes #52