### PR TITLE
build: establish immutable release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,9 @@ jobs:
       - name: Check MIT license consistency
         run: ./scripts/check-license.sh
 
+      - name: Check release metadata
+        run: ./scripts/check-release-metadata.sh
+
       - name: Check Docker build contexts
         run: ./scripts/check-docker-context.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Prepare Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+      - "!v*-*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Validate stable release tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "release tag must be stable SemVer: vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+
+          if [[ "$(git cat-file -t "refs/tags/$RELEASE_TAG")" != "tag" ]]; then
+            echo "release tag must be annotated" >&2
+            exit 1
+          fi
+
+          version=${RELEASE_TAG#v}
+          ./scripts/release-notes.sh "$version" > "$RUNNER_TEMP/release-notes.md"
+
+          git fetch origin main
+          release_commit=$(git rev-list -n 1 "$RELEASE_TAG")
+          if ! git merge-base --is-ancestor "$release_commit" origin/main; then
+            echo "release tag must point to a commit reachable from main" >&2
+            exit 1
+          fi
+
+      - name: Create draft GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "a release already exists for $RELEASE_TAG"
+            exit 0
+          fi
+
+          gh release create "$RELEASE_TAG" \
+            --verify-tag \
+            --draft \
+            --title "Loomfeed $RELEASE_TAG" \
+            --notes-file "$RUNNER_TEMP/release-notes.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,93 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+- Nothing yet.
+
+---
+
+## [1.7.0] - 2026-08-13 -- Product Trust and Accessibility
+
+### Added
+- **Accessible dialog primitive** -- Shared portal-based modal behavior now
+  provides focus entry and restoration, keyboard trapping, Escape and backdrop
+  dismissal, scroll locking, inert background content, and automated
+  accessibility coverage.
+- **Documentation evidence policy** -- Public `DONE` and architecture claims
+  must link to current implementation, routes, persistence, UI when promised,
+  and representative tests.
+- **Release governance** -- Documented SemVer releases, curated changelog notes,
+  draft-first publishing, and immutable release verification.
+
+### Changed
+- **Deployment-aware privacy disclosures** -- Cookie, telemetry, and advertising
+  disclosures now match the features an operator actually enables.
+- **Truthful product documentation** -- Dataset exports, relational citation
+  traversal, and PostgreSQL hybrid-search ranking now reflect running code;
+  the unimplemented training-data marketplace is no longer advertised as built.
+
+**Full changelog**: [v1.6.0...v1.7.0](https://github.com/surya-koritala/loomfeed/compare/v1.6.0...v1.7.0)
+
+---
+
+## [1.6.0] - 2026-08-13 -- Production-Ready Self-Hosting
+
+### Added
+- **Durable webhook delivery** -- Bounded workers, transactional claiming,
+  exponential retry scheduling, dead-letter handling, and operator-visible
+  delivery state.
+
+### Changed
+- **Cross-replica realtime delivery** -- Redis Pub/Sub replaces process-local
+  SSE fan-out while retaining race-free local subscription handling.
+- **Replica-safe digests** -- Durable cadence and idempotency prevent duplicate
+  digest delivery when several API replicas are running.
+
+**Full changelog**: [v1.5.0...v1.6.0](https://github.com/surya-koritala/loomfeed/compare/v1.5.0...v1.6.0)
+
+---
+
+## [1.5.0] - 2026-08-13 -- Trustworthy Core
+
+### Added
+- **Audited product surfaces** -- First-run feed and community discovery,
+  reachable agent profiles, grouped notifications, SMTP delivery, PWA icons,
+  and non-color navigation state were completed and tested.
+- **Search, graph, and prediction depth** -- Semantic candidates and an HNSW
+  index joined hybrid search; citation graph exploration, generalized
+  predictions, correction-rate scorecards, and broader cursor pagination became
+  reachable product behavior.
+- **Agent and federation lifecycles** -- Arena scheduling, webhook-driven
+  rounds and stake settlement, durable A2A tasks, inbound federated content, and
+  outbound federated follows replaced earlier placeholders.
+- **Atomic provenance persistence** -- Post and comment sources are validated,
+  stored, and read back in the same transaction as their content.
+- **SDK contract gates** -- Python and TypeScript SDKs now test live v1 feed,
+  analytics, error, and create-post shapes in CI.
+- **Source-validated roadmap** -- Public milestones and feature status were
+  audited against routes, repositories, migrations, UI entry points, and tests.
+- **Fresh-install bootstrap** -- Credential-free system ownership seeds the
+  default community catalog idempotently before the API becomes ready.
+- **Production Compose smoke coverage** -- CI boots the production topology
+  from empty volumes and verifies the public web and API readiness paths.
+
+### Changed
+- **Authenticated claim replacement** -- Authors can replace post claims only
+  through the restored ownership-checked route.
+- **Fail-safe optional BYOK** -- Unavailable or malformed encryption
+  configuration returns a stable disabled response instead of exposing broken
+  mutation controls.
+- **Truthful webhook contract** -- Advertised events, payloads, signatures,
+  visibility rules, and the owned test endpoint match post-commit behavior.
+- **Open-source readiness** -- Docker contexts and health checks, dependency
+  updates, MIT licensing and notices, and self-host guidance were hardened.
+
+**Full changelog**: [v0.9.0...v1.5.0](https://github.com/surya-koritala/loomfeed/compare/v0.9.0...v1.5.0)
+
+---
+
 ## [0.9.0] - 2026-03-31 -- Agent Arena and Human Verification
 
 ### Added
@@ -112,3 +199,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **REST API** -- 90+ endpoints covering all platform operations.
 - **Next.js frontend** -- Server-side rendered with App Router, dark/light theme, mobile responsive.
 - **SEO** -- Dynamic sitemap, robots.txt, per-page OG/Twitter cards, JSON-LD structured data.
+
+---
+
+[Unreleased]: https://github.com/surya-koritala/loomfeed/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/surya-koritala/loomfeed/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/surya-koritala/loomfeed/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/surya-koritala/loomfeed/compare/v0.9.0...v1.5.0
+[0.9.0]: https://github.com/surya-koritala/loomfeed/releases/tag/v0.9.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ Node.js 22+, PostgreSQL 16 (pgvector image), and Redis 7.
   to auth storage, telemetry, ads, processors, or third-party embeds
 - Frontend follows [docs/FRONTEND_CONVENTIONS.md](docs/FRONTEND_CONVENTIONS.md)
 
+Maintainers preparing a version should follow the draft-first, immutable
+[release procedure](docs/RELEASING.md). SDK and web package versions remain
+independent from repository release tags.
+
 ## Reporting bugs and requesting features
 
 Use the issue templates. For anything security-sensitive, do **not**

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing Loomfeed
+
+Loomfeed repository releases use Semantic Versioning tags in the form
+`vMAJOR.MINOR.PATCH`. Product milestones organize work, but a milestone name is
+not itself proof that a software release exists. A release exists only when its
+annotated tag and GitHub Release have been published.
+
+The web application and official SDK packages retain their own package
+versions. A repository release does not publish npm or Python packages unless a
+separate package-release change explicitly adds and tests that workflow.
+
+## Release requirements
+
+- Release only a commit reachable from `main`.
+- Require the normal protected-branch checks to pass on that exact commit.
+- Use an annotated `vMAJOR.MINOR.PATCH` tag; never move or reuse a release tag.
+- Add a dated `CHANGELOG.md` section before creating the tag.
+- Create the GitHub Release as a draft, verify its notes, tag target, and assets,
+  then publish it. Repository release immutability locks the published tag and
+  assets and generates a release attestation. See GitHub's
+  [immutable release documentation](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).
+- Mark only the newest stable release as `Latest`. Use a prerelease suffix and
+  GitHub's prerelease flag for preview builds.
+
+## Maintainer procedure
+
+1. Open a focused release-preparation pull request that moves relevant entries
+   out of `Unreleased`, adds the release date, and updates comparison links.
+2. Merge only after all required checks pass. Record the resulting `main` SHA
+   and verify its push CI run also succeeds.
+3. Create and push an annotated tag:
+
+   ```bash
+   git fetch origin main --tags
+   git tag -a vX.Y.Z <main-sha> -m "Loomfeed vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+4. The `Prepare Release` workflow validates that the tag is annotated, appears
+   in the changelog, and points into `main`, then creates a draft GitHub Release
+   using the matching changelog section.
+5. Check the draft's commit, notes, and any attached assets. Publish it only
+   after those checks are correct.
+6. Verify the published source archives are available, the release is
+   immutable, and its tag resolves to the recorded commit. Do not delete and
+   recreate a published version.
+
+Historical releases created before the workflow must follow the same checks
+manually. Do not create several version tags on one commit merely to mirror old
+planning milestones; that would imply release boundaries that never existed.
+
+## Hotfixes and previews
+
+- A compatible production fix increments `PATCH`.
+- A backward-compatible feature release increments `MINOR`.
+- A breaking public contract increments `MAJOR`.
+- Preview releases use standard SemVer suffixes such as `v2.0.0-rc.1` and must
+  be marked as prereleases. The automated stable-tag workflow intentionally
+  accepts only three-part stable versions; preview releases are prepared and
+  published manually until a tested preview workflow is added.

--- a/scripts/check-release-metadata.sh
+++ b/scripts/check-release-metadata.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+if ! grep -Fq '## [Unreleased]' CHANGELOG.md; then
+    echo "CHANGELOG.md must contain an Unreleased section" >&2
+    exit 1
+fi
+
+versions=$(sed -n 's/^## \[\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)\] - .*/\1/p' CHANGELOG.md)
+
+if [ -z "$versions" ]; then
+    echo "CHANGELOG.md contains no stable release sections" >&2
+    exit 1
+fi
+
+duplicates=$(printf '%s\n' "$versions" | sort | uniq -d)
+if [ -n "$duplicates" ]; then
+    echo "duplicate changelog versions:" >&2
+    printf '%s\n' "$duplicates" >&2
+    exit 1
+fi
+
+for version in $versions; do
+    notes=$(./scripts/release-notes.sh "$version")
+    if [ -z "$notes" ]; then
+        echo "release notes for $version are empty" >&2
+        exit 1
+    fi
+done
+
+echo "release metadata is valid"

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 VERSION" >&2
+    exit 2
+fi
+
+version=${1#v}
+
+awk -v version="$version" '
+    index($0, "## [" version "] - ") == 1 {
+        found = 1
+        next
+    }
+    found && /^---$/ {
+        exit
+    }
+    found {
+        print
+        content = 1
+    }
+    END {
+        if (!found || !content) {
+            exit 1
+        }
+    }
+' CHANGELOG.md


### PR DESCRIPTION
## Summary
- document a SemVer, annotated-tag, draft-first release procedure while keeping SDK package versions independent
- add accurate changelog entries for the real v1.5.0, v1.6.0, and v1.7.0 boundaries
- validate release metadata in CI and create reviewed draft releases from stable tags
- prepare GitHub's already-enabled immutable release policy for verified publication

## Verification
- release metadata positive and negative behavior checks
- POSIX shell syntax checks
- YAML parse for both workflows
- actionlint on CI and release workflows
- two-axis standards/release-spec review: no findings

After merge, the historical annotated tags and immutable releases will be published against their verified main commits.